### PR TITLE
add example with OpenMapTiles style and tile hosting

### DIFF
--- a/example/openmaptiles.html
+++ b/example/openmaptiles.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+  <title>OpenMapTiles</title>
+  <link rel="stylesheet" href="https://openlayers.org/en/v4.5.0/css/ol.css">
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+    }
+    #map {
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://openlayers.org/en/v4.5.0/build/ol.js"></script>
+  <script src="../dist/olms.js"></script>
+  <script>
+  var map = olms.apply('map', 'https://openmaptiles.github.io/klokantech-basic-gl-style/style-cdn.json');
+  </script>
+</body>


### PR DESCRIPTION
I think supporting OpenMapTiles style would be great. This example works quite well on some aspects, but there are a few bugs.

Labels are not rendered properly, and some zones become black when zooming towards them.

To see the same style fully rendered you can see here : https://www.tilehosting.com/