### PR TITLE
Fix how zoom level is interpreted from a Mapbox style

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -290,6 +290,11 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
     if (zoom == -1) {
       zoom = getZoomForResolution(resolution, resolutions);
     }
+    if (zoom > 0) {
+      // mapbox zoom level is counted from 0 to X, OL zoom level is counted from 1 to X
+      // so here we substract 1 to adjust to zoom level described in Mapbox Style
+      zoom -= 1;
+    }
     const type = types[feature.getGeometry().getType()];
     const f = {
       properties: properties,


### PR DESCRIPTION
As Mapbox count zoomlevel differently than OpenLayers, there was a misinterpretation and OL was showing layers 1 zoom level too early, this fix this issue.

You can see this difference in zoomlevel interpretation on this codepen (zoom by the Alps around zoom level 8 on mapbox to see peaks appearing on OL when the style says it should not appear before zoom level 9) : https://codepen.io/pakb/pen/NoLJYB