### PR TITLE
adding olms-debug target

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "webpack-dev-server --config ./webpack.config.js",
     "prepare": "npm run doc && npm run build",
     "build": "webpack-cli --mode=production --config ./webpack.config.olms.js && webpack-cli --mode=production",
+    "build-debug": "webpack-cli --mode=development --config ./webpack.config.olms-debug.js && webpack-cli --mode=development",
     "doc": "documentation readme -s API index.js",
     "karma": "karma start test/karma.conf.js",
     "lint": "eslint test example *.js",

--- a/webpack.config.olms-debug.js
+++ b/webpack.config.olms-debug.js
@@ -1,0 +1,51 @@
+const path = require('path');
+
+module.exports = {
+  entry: './olms.js',
+  devtool: 'source-map',
+  node: {fs: 'empty'},
+  mode: 'development',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        include: [
+          __dirname,
+          path.resolve(__dirname, 'exmaple'),
+          /node_modules\/(?!(ol|@mapbox\/mapbox-gl-style-spec)\/)/
+        ],
+        use: {
+          loader: 'buble-loader'
+        }
+      }
+    ]
+  },
+  output: {
+    path: path.resolve('./dist'), // Path of output file
+    filename: 'olms-debug.js',
+    library: 'olms',
+    libraryTarget: 'assign',
+    libraryExport: 'default'
+  },
+  externals: {
+    'ol/style/Style': 'ol.style.Style',
+    'ol/style/Circle': 'ol.style.Circle',
+    'ol/style/Icon': 'ol.style.Icon',
+    'ol/style/Stroke': 'ol.style.Stroke',
+    'ol/style/Fill': 'ol.style.Fill',
+    'ol/geom/Point': 'ol.geom.Point',
+    'ol/proj': 'ol.proj',
+    'ol/tilegrid': 'ol.tilegrid',
+    'ol/tilegrid/TileGrid': 'ol.tilegrid.TileGrid',
+    'ol/format/GeoJSON': 'ol.format.GeoJSON',
+    'ol/format/MVT': 'ol.format.MVT',
+    'ol/Map': 'ol.Map',
+    'ol/Observable': 'ol.Observable',
+    'ol/layer/Tile': 'ol.layer.Tile',
+    'ol/layer/Vector': 'ol.layer.Vector',
+    'ol/layer/VectorTile': 'ol.layer.VectorTile',
+    'ol/source/TileJSON': 'ol.source.TileJSON',
+    'ol/source/Vector': 'ol.source.Vector',
+    'ol/source/VectorTile': 'ol.source.VectorTile'
+  }
+};


### PR DESCRIPTION
For development of "legacy" (e.g. non modular) JS apps it would be useful to have an aggregated `olms-debug.js` build target as well. I propose a solution with this PR, but since I'm not very familiar with webpack yet it might not be the cleanest solution...