### PR TITLE
Allow zoom levels according to the style specification

### DIFF
--- a/index.js
+++ b/index.js
@@ -397,7 +397,7 @@ function updateRasterLayerProperties(glLayer, layer, view) {
   const zoom = view.getZoom();
   const opacity = getValue(glLayer, 'paint', 'raster-opacity', zoom, emptyObj);
   layer.setOpacity(opacity);
-  layer.setVisible(zoom >= (glLayer.minzoom || 0) && zoom < (glLayer.maxzoom || 24));
+  layer.setVisible(zoom >= (glLayer.minzoom || 0) && zoom < (glLayer.maxzoom || Infinity));
 }
 
 function processStyle(glStyle, map, baseUrl, host, path, accessToken) {

--- a/index.js
+++ b/index.js
@@ -397,7 +397,8 @@ function updateRasterLayerProperties(glLayer, layer, view) {
   const zoom = view.getZoom();
   const opacity = getValue(glLayer, 'paint', 'raster-opacity', zoom, emptyObj);
   layer.setOpacity(opacity);
-  layer.setVisible(zoom >= (glLayer.minzoom || 0) && zoom < (glLayer.maxzoom || Infinity));
+  const visible = (glLayer.layout ? glLayer.layout.visibility !== 'none' : true);
+  layer.setVisible(visible && zoom >= (glLayer.minzoom || 0) && zoom < (glLayer.maxzoom || Infinity));
 }
 
 function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
@@ -449,7 +450,6 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
           layer = setupVectorLayer(glSource, accessToken, url);
         } else if (glSource.type == 'raster') {
           layer = setupRasterLayer(glSource, url);
-          layer.setVisible(glLayer.layout ? glLayer.layout.visibility !== 'none' : true);
           view.on('change:resolution', updateRasterLayerProperties.bind(this, glLayer, layer, view));
           updateRasterLayerProperties(glLayer, layer, view);
         } else if (glSource.type == 'geojson') {

--- a/index.js
+++ b/index.js
@@ -403,6 +403,9 @@ function updateRasterLayerProperties(glLayer, layer, view) {
 function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
   const promises = [];
   const view = map.getView();
+  if (view.getMaxZoom() > 25) {
+    view.setMaxZoom(25);
+  }
   if ('center' in glStyle && !view.getCenter()) {
     view.setCenter(fromLonLat(glStyle.center));
   }

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -181,7 +181,7 @@ function fromTemplate(text, properties) {
 export default function(olLayer, glStyle, source, resolutions, spriteData, spriteImageUrl, getFonts) {
   if (!resolutions) {
     resolutions = [];
-    for (let res = 78271.51696402048; resolutions.length < 21; res /= 2) {
+    for (let res = 78271.51696402048; resolutions.length <= 24; res /= 2) {
       resolutions.push(res);
     }
   }


### PR DESCRIPTION
Currently we limit the zoom levels more than the style spec does. With this pull request, we support the full zoom range up to z24. For the view, we now make sure that we do not go beyond that.