### PR TITLE
Add getLayers utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,12 @@ fetch('data/states.json').then(function(response) {
     -   [Parameters](#parameters-3)
 -   [getLayer](#getlayer)
     -   [Parameters](#parameters-4)
--   [getSource](#getsource)
+-   [getLayers](#getlayers)
     -   [Parameters](#parameters-5)
--   [stylefunction](#stylefunction)
+-   [getSource](#getsource)
     -   [Parameters](#parameters-6)
+-   [stylefunction](#stylefunction)
+    -   [Parameters](#parameters-7)
 
 ### applyStyle
 
@@ -212,7 +214,22 @@ OpenLayers layer instance when they use the same Mapbox Style `source`.
 -   `map` **ol.Map** OpenLayers Map.
 -   `layerId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Mapbox Style layer id.
 
-Returns **ol.layer.Layer** layer OpenLayers layer instance.
+Returns **ol.layer.Layer** OpenLayers layer instance.
+
+### getLayers
+
+```js
+import {getLayers} from 'ol-mapbox-style';
+```
+
+Get the OpenLayers layer instances for the provided Mapbox Style `source`.
+
+#### Parameters
+
+-   `map` **ol.Map** OpenLayers Map.
+-   `sourceId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Mapbox Style source id.
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;ol.layer.Layer>** OpenLayers layer instances.
 
 ### getSource
 
@@ -227,7 +244,7 @@ Get the OpenLayers source instance for the provided Mapbox Style `source`.
 -   `map` **ol.Map** OpenLayers Map.
 -   `sourceId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Mapbox Style source id.
 
-Returns **ol.layer.Layer** layer OpenLayers layer instance.
+Returns **ol.source.Source** OpenLayers source instance.
 
 ### stylefunction
 

--- a/index.js
+++ b/index.js
@@ -659,7 +659,7 @@ function finalizeLayer(layer, layerIds, glStyle, path, map) {
  * OpenLayers layer instance when they use the same Mapbox Style `source`.
  * @param {ol.Map} map OpenLayers Map.
  * @param {string} layerId Mapbox Style layer id.
- * @return {ol.layer.Layer} layer OpenLayers layer instance.
+ * @return {ol.layer.Layer} OpenLayers layer instance.
  */
 export function getLayer(map, layerId) {
   const layers = map.getLayers().getArray();
@@ -672,12 +672,32 @@ export function getLayer(map, layerId) {
 
 /**
  * ```js
+ * import {getLayers} from 'ol-mapbox-style';
+ * ```
+ * Get the OpenLayers layer instances for the provided Mapbox Style `source`.
+ * @param {ol.Map} map OpenLayers Map.
+ * @param {string} sourceId Mapbox Style source id.
+ * @return {Array<ol.layer.Layer>} OpenLayers layer instances.
+ */
+export function getLayers(map, sourceId) {
+  const result = [];
+  const layers = map.getLayers().getArray();
+  for (let i = 0, ii = layers.length; i < ii; ++i) {
+    if (layers[i].get('mapbox-source').indexOf(sourceId) !== -1) {
+      result.push(layers[i]);
+    }
+  }
+  return result;
+}
+
+/**
+ * ```js
  * import {getSource} from 'ol-mapbox-style';
  * ```
  * Get the OpenLayers source instance for the provided Mapbox Style `source`.
  * @param {ol.Map} map OpenLayers Map.
  * @param {string} sourceId Mapbox Style source id.
- * @return {ol.layer.Layer} layer OpenLayers layer instance.
+ * @return {ol.source.Source} OpenLayers source instance.
  */
 export function getSource(map, sourceId) {
   const layers = map.getLayers().getArray();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
 import should from 'should';
-import olms, {applyBackground, apply, getLayer, getSource} from '..';
+import olms, {applyBackground, apply, getLayer, getLayers, getSource} from '..';
 import Map from 'ol/Map';
 import TileSource from 'ol/source/Tile';
 import VectorSource from 'ol/source/Vector';
@@ -222,6 +222,25 @@ describe('ol-mapbox-style', function() {
       });
     });
   });
+
+  describe('getLayers', function() {
+    let target;
+    beforeEach(function() {
+      target = document.createElement('div');
+    });
+
+    it('returns an array of layers', function(done) {
+      const map = apply(target, brightV9);
+
+      map.once('change:mapbox-style', function() {
+        const layers = getLayers(map, 'mapbox');
+        should(layers).be.an.instanceOf(Array);
+        should(layers[0]).be.an.instanceOf(VectorTileLayer);
+        done();
+      });
+    });
+  });
+
 
   describe('getSource', function() {
     let target;


### PR DESCRIPTION
There are situations where applications need all the layers that `ol-mapbox-style` created from a `sources` entry of the Mapbox Style document. This pull request adds a `getLayers()` function for this purpose.