### PR TITLE
Add text padding support

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -637,6 +637,10 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
           } else {
             text.setStroke(undefined);
           }
+          const textPadding = getValue(layer, 'layout', 'text-padding', zoom, f);
+          if (textPadding) {
+            text.setPadding([textPadding, textPadding, textPadding, textPadding])
+          }
           style.setZIndex(99999 - index);
         }
       }

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -586,7 +586,9 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
             style.setGeometry(undefined);
           }
           if (!style.getText()) {
-            style.setText(text || new Text());
+            style.setText(text || new Text({
+              padding: [2, 2, 2, 2]
+            }));
           }
           text = style.getText();
           const textSize = getValue(layer, 'layout', 'text-size', zoom, f);
@@ -638,8 +640,9 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
             text.setStroke(undefined);
           }
           const textPadding = getValue(layer, 'layout', 'text-padding', zoom, f);
-          if (textPadding) {
-            text.setPadding([textPadding, textPadding, textPadding, textPadding])
+          const padding = text.getPadding();
+          if (textPadding !== padding[0]) {
+            padding[0] = padding[1] = padding[2] = padding[3] = textPadding;
           }
           style.setZIndex(99999 - index);
         }


### PR DESCRIPTION
Would fix part of https://github.com/openlayers/ol-mapbox-style/issues/137

Text-padding should be a number, as defined in the [Mapbox spec](https://docs.mapbox.com/mapbox-gl-js/style-spec#layout-symbol-text-padding) so it is converted to an array as wanted in [OL spec](https://openlayers.org/en/latest/apidoc/module-ol_style_Text-Text.html)