### PR TITLE
fix getLayers() for non-mapbox layers

### DIFF
--- a/index.js
+++ b/index.js
@@ -683,7 +683,8 @@ export function getLayers(map, sourceId) {
   const result = [];
   const layers = map.getLayers().getArray();
   for (let i = 0, ii = layers.length; i < ii; ++i) {
-    if (layers[i].get('mapbox-source').indexOf(sourceId) !== -1) {
+    const mapboxLayer = layers[i].get('mapbox-source');
+    if (mapboxLayer && mapboxLayer.indexOf(sourceId) !== -1) {
       result.push(layers[i]);
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -231,6 +231,7 @@ describe('ol-mapbox-style', function() {
 
     it('returns an array of layers', function(done) {
       const map = apply(target, brightV9);
+      map.addLayer(new VectorTileLayer());
 
       map.once('change:mapbox-style', function() {
         const layers = getLayers(map, 'mapbox');


### PR DESCRIPTION
This prevents non-mapbox layers breaking the code at `getLayers()`. 
Also added a small test with an empty `VectorTileLayer`.