### PR TITLE
Fix getSource, getLayer and getLayers

### DIFF
--- a/index.js
+++ b/index.js
@@ -664,7 +664,8 @@ function finalizeLayer(layer, layerIds, glStyle, path, map) {
 export function getLayer(map, layerId) {
   const layers = map.getLayers().getArray();
   for (let i = 0, ii = layers.length; i < ii; ++i) {
-    if (layers[i].get('mapbox-layers').indexOf(layerId) !== -1) {
+    const mapboxLayers = layers[i].get('mapbox-layers');
+    if (mapboxLayers && mapboxLayers.indexOf(layerId) !== -1) {
       return layers[i];
     }
   }
@@ -683,7 +684,7 @@ export function getLayers(map, sourceId) {
   const result = [];
   const layers = map.getLayers().getArray();
   for (let i = 0, ii = layers.length; i < ii; ++i) {
-    if (layers[i].get('mapbox-source').indexOf(sourceId) !== -1) {
+    if (layers[i].get('mapbox-source') === sourceId) {
       result.push(layers[i]);
     }
   }
@@ -703,7 +704,7 @@ export function getSource(map, sourceId) {
   const layers = map.getLayers().getArray();
   for (let i = 0, ii = layers.length; i < ii; ++i) {
     const source = layers[i].getSource();
-    if (layers[i].get('mapbox-source').indexOf(sourceId) !== -1) {
+    if (layers[i].get('mapbox-source') === sourceId) {
       return source;
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -214,11 +214,13 @@ describe('ol-mapbox-style', function() {
     });
 
     it('returns a layer', function(done) {
-      const map = apply(target, brightV9);
-
-      map.once('change:mapbox-style', function() {
+      olms(target, brightV9).then(function(map) {
+        // add another layer that has no 'mapbox-layers' set
+        map.addLayer(new VectorTileLayer());
         should(getLayer(map, 'landuse_park')).be.an.instanceOf(VectorTileLayer);
         done();
+      }).catch(function(error) {
+        done(error);
       });
     });
   });
@@ -230,13 +232,16 @@ describe('ol-mapbox-style', function() {
     });
 
     it('returns an array of layers', function(done) {
-      const map = apply(target, brightV9);
-
-      map.once('change:mapbox-style', function() {
+      olms(target, brightV9).then(function(map) {
+        // add another layer that has no 'mapbox-layers' set
+        map.addLayer(new VectorTileLayer());
         const layers = getLayers(map, 'mapbox');
         should(layers).be.an.instanceOf(Array);
         should(layers[0]).be.an.instanceOf(VectorTileLayer);
+        should(getLayers(map, 'mapbo').length).eql(0);
         done();
+      }).catch(function(error) {
+        done(error);
       });
     });
   });
@@ -249,11 +254,14 @@ describe('ol-mapbox-style', function() {
     });
 
     it('returns a source', function(done) {
-      const map = apply(target, brightV9);
-
-      map.once('change:mapbox-style', function() {
+      olms(target, brightV9).then(function(map) {
+        // add another layer that has no 'mapbox-source' set
+        map.addLayer(new VectorTileLayer());
         should(getSource(map, 'mapbox')).be.an.instanceOf(VectorTileSource);
+        should(getSource(map, 'mapbo')).be.undefined();
         done();
+      }).catch(function(error) {
+        done(error);
       });
     });
   });


### PR DESCRIPTION
This pull request is a replacement for #143 and fixes more underlying issues of the `getLayer()`, `getLayers()` and `getSource()` function. The `indexOf` check does not make sense for `getSource()` and `getLayers()` because the `mapbox-source` property of the layer is a string, not an array. And for `getLayer()`, the fix proposed by @RobertOrthofer in #143 needs to be applied.

Thanks @RobertOrthofer for inspiring this change.