### PR TITLE
Fix zoom, minzoom and maxzoom handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,27 @@
 
 ## Next version
 
+### Breaking changes
+
+#### Zoom handling
+
+The way how we handle `zoom`, `minzoom` and `maxzoom` throughout the library has been reworked:
+
+* When ol-mapbox-style creates an `ol/View` instance, it will be configured with the zoom level range that mapbox-gl uses. When updating from previous versions, you will notice that the zoom levels of the OpenLayers view will now match those in the Mapbox Style object. Previously OpenLayers zoom levels were higher by 1.
+* When a Mapbox Style object is configured with a `zoom`, the zoom level will now be interpreted like in mapbox-gl, i.e. you will be zoomed in one level deeper than before the update.
+* `minzoom` and `maxzoom` on a Mapbox Style layer were previously determined by the tile size of the underlying source. For raster sources with a tile size of 256, this means that `minzoom` and `maxzoom` are zoomed in one level deeper than before the update. For sources with a tile size of 512, nothing changes.
+* `minzoom` and `maxzoom` on a Mapbox Style source now influence the `ol/tilegrid/TileGrid` that ol-mapbox-style creates for a source in a different way. The resolutions will always match mapbox-gl default zoom levels.
+* `minzoom` and `maxzoom` on Mapbox Style layers no longer  influences whether the `ol/layer/Layer` instance is  set `visible` at a certain resolution. Instead, the layer's `maxResolution` and `minResolution` are set.
+
+### Other changes
+
+* Add support for `text-letter-spacing`
+
 ## 3.9.0
 
 * Reduce garbage by reusing padding array
 * Fix `getSource()`, `getLayer()` and `getLayers()` utility functions
+* Add support for `text-padding`
 
 ## 3.8.0
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ import {fromLonLat} from 'ol/proj';
 import {createXYZ} from 'ol/tilegrid';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import Map from 'ol/Map';
+import View from 'ol/View';
 import GeoJSON from 'ol/format/GeoJSON';
 import MVT from 'ol/format/MVT';
 import {unByKey} from 'ol/Observable';
@@ -399,14 +400,11 @@ function updateRasterLayerProperties(glLayer, layer, view) {
 function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
   const promises = [];
   const view = map.getView();
-  if (view.getMaxZoom() > 25) {
-    view.setMaxZoom(25);
-  }
   if ('center' in glStyle && !view.getCenter()) {
     view.setCenter(fromLonLat(glStyle.center));
   }
   if ('zoom' in glStyle && view.getZoom() === undefined) {
-    view.setZoom(glStyle.zoom);
+    view.setResolution(defaultResolutions[0] / Math.pow(2, glStyle.zoom));
   }
   if (!view.getCenter() || view.getZoom() === undefined) {
     view.fit(view.getProjection().getExtent(), {
@@ -523,7 +521,10 @@ export default function olms(map, style) {
 
   if (!(map instanceof Map)) {
     map = new Map({
-      target: map
+      target: map,
+      view: new View({
+        resolutions: defaultResolutions
+      })
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -308,7 +308,7 @@ function setupVectorLayer(glSource, accessToken, url) {
           origin: tileGrid.getOrigin(),
           extent: extent || tileGrid.getExtent(),
           minZoom: minZoom,
-          resolutions: defaultResolutions.slice(0, maxZoom),
+          resolutions: defaultResolutions.slice(0, maxZoom + 1),
           tileSize: 512
         }),
         urls: tiles

--- a/index.js
+++ b/index.js
@@ -440,6 +440,9 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
         maxZoom = 0;
         glSource = glStyle.sources[id];
         url = glSource.url;
+        if (url && path && url.startsWith('.')) {
+          url = path + url;
+        }
 
         if (glSource.type == 'vector') {
           layer = setupVectorLayer(glSource, accessToken, url);

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ import TileJSON from 'ol/source/TileJSON';
 import VectorSource from 'ol/source/Vector';
 import VectorTileSource from 'ol/source/VectorTile';
 import {Color} from '@mapbox/mapbox-gl-style-spec';
+import {defaultResolutions, getZoomForResolution} from './util';
 
 const fontFamilyRegEx = /font-family: ?([^;]*);/;
 const stripQuotesRegEx = /("|')/g;
@@ -297,26 +298,20 @@ function setupVectorLayer(glSource, accessToken, url) {
       }
       const tileGrid = tilejson.getTileGrid();
       const extent = extentFromTileJSON(tileJSONDoc);
-      const tileSize = tileJSONDoc.tileSize || 512;
+      const minZoom = tileJSONDoc.minzoom || 0;
+      const maxZoom = tileJSONDoc.maxzoom || 22;
       const source = new VectorTileSource({
         attributions: tilejson.getAttributions(),
         format: new MVT(),
         tileGrid: new TileGrid({
           origin: tileGrid.getOrigin(),
-          extent: extent,
-          resolutions: createXYZ({
-            minZoom: tileGrid.getMinZoom(),
-            maxZoom: tileGrid.getMaxZoom(),
-            tileSize: tileSize
-          }).getResolutions(),
-          tileSize: tileSize
+          extent: extent || tileGrid.getExtent(),
+          minZoom: minZoom,
+          resolutions: defaultResolutions.slice(0, maxZoom),
+          tileSize: 512
         }),
         urls: tiles
       });
-      if (tileGrid.getMinZoom() > 0) {
-        layer.setMaxResolution(
-          tileGrid.getResolution(tileGrid.getMinZoom()));
-      }
       unByKey(key);
       layer.setSource(source);
     } else if (state === 'error') {
@@ -345,14 +340,16 @@ function setupRasterLayer(glSource, url) {
       const tileJSONDoc = source.getTileJSON();
       const extent = extentFromTileJSON(tileJSONDoc);
       const tileGrid = source.getTileGrid();
-      const tileSize = tileJSONDoc.tileSize || 256;
+      const tileSize = tileJSONDoc.tileSize || 512;
+      const minZoom = tileJSONDoc.minzoom || 0;
+      const maxZoom = tileJSONDoc.maxzoom || 22;
       // Only works when using ES modules
       source.tileGrid = new TileGrid({
         origin: tileGrid.getOrigin(),
-        extent: extent,
+        extent: extent || tileGrid.getExtent(),
+        minZoom: minZoom,
         resolutions: createXYZ({
-          minZoom: tileGrid.getMinZoom(),
-          maxZoom: tileGrid.getMaxZoom(),
+          maxZoom: maxZoom,
           tileSize: tileSize
         }).getResolutions(),
         tileSize: tileSize
@@ -397,8 +394,6 @@ function updateRasterLayerProperties(glLayer, layer, view) {
   const zoom = view.getZoom();
   const opacity = getValue(glLayer, 'paint', 'raster-opacity', zoom, emptyObj);
   layer.setOpacity(opacity);
-  const visible = (glLayer.layout ? glLayer.layout.visibility !== 'none' : true);
-  layer.setVisible(visible && zoom >= (glLayer.minzoom || 0) && zoom < (glLayer.maxzoom || Infinity));
 }
 
 function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
@@ -430,7 +425,7 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
   const glLayers = glStyle.layers;
   let layerIds = [];
 
-  let glLayer, glSource, glSourceId, id, layer, url;
+  let glLayer, glSource, glSourceId, id, layer, minZoom, maxZoom, url;
   for (let i = 0, ii = glLayers.length; i < ii; ++i) {
     glLayer = glLayers[i];
     if (glLayer.type == 'background') {
@@ -440,9 +435,11 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
       // this technique assumes gl layers will be in a particular order
       if (id != glSourceId) {
         if (layerIds.length) {
-          promises.push(finalizeLayer(layer, layerIds, glStyle, path, map));
+          promises.push(finalizeLayer(layer, layerIds, glStyle, path, map, minZoom, maxZoom));
           layerIds = [];
         }
+        minZoom = 24;
+        maxZoom = 0;
         glSource = glStyle.sources[id];
         url = glSource.url;
 
@@ -450,6 +447,7 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
           layer = setupVectorLayer(glSource, accessToken, url);
         } else if (glSource.type == 'raster') {
           layer = setupRasterLayer(glSource, url);
+          layer.setVisible(glLayer.layout ? glLayer.layout.visibility !== 'none' : true);
           view.on('change:resolution', updateRasterLayerProperties.bind(this, glLayer, layer, view));
           updateRasterLayerProperties(glLayer, layer, view);
         } else if (glSource.type == 'geojson') {
@@ -461,9 +459,16 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
         }
       }
       layerIds.push(glLayer.id);
+      minZoom = Math.min(
+        'minzoom' in glSource ?
+          // Limit layer minzoom to source minzoom. No underzooming, see https://github.com/mapbox/mapbox-gl-js/issues/7388
+          Math.max(getZoomForResolution(layer.getSource().getTileGrid().getResolutions()[glSource.minzoom], defaultResolutions), glLayer.minzoom || 0) :
+          glLayer.minzoom || 0,
+        minZoom);
+      maxZoom = Math.max(glLayer.maxzoom || 24, maxZoom);
     }
   }
-  promises.push(finalizeLayer(layer, layerIds, glStyle, path, map));
+  promises.push(finalizeLayer(layer, layerIds, glStyle, path, map, minZoom, maxZoom));
   map.set('mapbox-style', glStyle);
   return Promise.all(promises);
 }
@@ -613,10 +618,18 @@ export function apply(map, style) {
  * @param {string|undefined} path The path part of the style URL. Only required
  * when a relative path is used with the `"sprite"` property of the style.
  * @param {ol.Map} map OpenLayers Map.
+ * @param {number} minZoom Minimum zoom.
+ * @param {number} maxZoom Maximum zoom.
  * @return {Promise} Returns a promise that resolves after the source has
  * been set on the specified layer, and the style has been applied.
  */
-function finalizeLayer(layer, layerIds, glStyle, path, map) {
+function finalizeLayer(layer, layerIds, glStyle, path, map, minZoom, maxZoom) {
+  if (minZoom > 0) {
+    layer.setMaxResolution(defaultResolutions[minZoom] + 1e-9);
+  }
+  if (maxZoom < 24) {
+    layer.setMinResolution(defaultResolutions[maxZoom] + 1e-9);
+  }
   return new Promise(function(resolve, reject) {
     const setStyle = function() {
       const source = layer.getSource();

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -19,7 +19,7 @@ import {
   featureFilter as createFilter
 } from '@mapbox/mapbox-gl-style-spec';
 import mb2css from 'mapbox-to-css-font';
-import {deg2rad, getZoomForResolution} from './util';
+import {deg2rad, defaultResolutions, getZoomForResolution} from './util';
 
 const isFunction = fn.isFunction;
 const convertFunction = fn.convertFunction;
@@ -179,13 +179,7 @@ function fromTemplate(text, properties) {
  * @return {ol.style.StyleFunction} Style function for use in
  * `ol.layer.Vector` or `ol.layer.VectorTile`.
  */
-export default function(olLayer, glStyle, source, resolutions, spriteData, spriteImageUrl, getFonts) {
-  if (!resolutions) {
-    resolutions = [];
-    for (let res = 78271.51696402048; resolutions.length <= 24; res /= 2) {
-      resolutions.push(res);
-    }
-  }
+export default function(olLayer, glStyle, source, resolutions = defaultResolutions, spriteData, spriteImageUrl, getFonts) {
   if (typeof glStyle == 'string') {
     glStyle = JSON.parse(glStyle);
   }

--- a/test/fixtures/hot-osm/hot-osm.json
+++ b/test/fixtures/hot-osm/hot-osm.json
@@ -19,10 +19,10 @@
   "sources": {
     "osm": {
       "type": "vector",
-      "url": "https://osm-lambda.tegola.io/v1/capabilities/osm.json"
+      "url": "./osm.json"
     }
   },
-  "sprite": "https://go-spatial.github.io/carto-assets/spritesets/osm_tegola_spritesheet",
+  "sprite": "./osm_tegola_spritesheet",
   "glyphs": "https://go-spatial.github.io/carto-assets/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,6 @@ import VectorTileLayer from 'ol/layer/VectorTile';
 import VectorTileSource from 'ol/source/VectorTile';
 import {toLonLat} from 'ol/proj';
 
-import HotOsm from './fixtures/hot-osm/hot-osm.json';
 import brightV9 from 'mapbox-gl-styles/styles/bright-v9.json';
 import {defaultResolutions} from '../util';
 delete brightV9.sprite;
@@ -157,7 +156,7 @@ describe('ol-mapbox-style', function() {
 
     it('handles vector sources from TileJSON', function(done) {
 
-      olms(target, HotOsm)
+      olms(target, './fixtures/hot-osm/hot-osm.json')
         .then(function(map) {
           const center = toLonLat(map.getView().getCenter());
           should(center[0]).be.approximately(8.54806714892635, 1e-8);
@@ -174,7 +173,7 @@ describe('ol-mapbox-style', function() {
     });
 
     it('creates a view with default resolutions', function(done) {
-      olms(target, HotOsm)
+      olms(target, './fixtures/hot-osm/hot-osm.json')
         .then(function(map) {
           should(map.getView().getResolutions()).eql(defaultResolutions);
           done();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,6 +162,7 @@ describe('ol-mapbox-style', function() {
           should(center[0]).be.approximately(8.54806714892635, 1e-8);
           should(center[1]).be.approximately(47.37180823552663, 1e-8);
           should(map.getView().getZoom()).equal(12.241790506353492);
+          should(map.getView().getResolution()).equal(defaultResolutions[0] / Math.pow(2, 12.241790506353492));
           const layer = map.getLayers().item(0);
           const source = layer.getSource();
           should(source).be.instanceof(VectorTileSource);
@@ -255,10 +256,120 @@ describe('ol-mapbox-style', function() {
           });
       });
 
-      it('handles visibility for raster layers', function(done) {
+      it('handles visibility', function(done) {
         olms(target, context)
           .then(function(map) {
             should(map.getLayers().item(0).get('visible')).be.false();
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+
+    });
+
+    describe('vector sources and layers', function() {
+
+      let context;
+
+      beforeEach(function() {
+        context = {
+          'version': 8,
+          'name': 'osm',
+          'sources': {
+            'osm': {
+              'type': 'vector',
+              'bounds': [-180, -85.0511, 180, 85.0511],
+              'minzoom': 0,
+              'maxzoom': 20,
+              'tiles': [
+                'https://osm-lambda.tegola.io/v1/maps/osm/{z}/{x}/{y}.pbf'
+              ]
+            }
+          },
+          'layers': [{
+            'id': 'airports',
+            'type': 'fill',
+            'source': 'osm',
+            'source-layer': 'transport_areas',
+            'minzoom': 12,
+            'maxzoom': 23,
+            'filter': [
+              'all',
+              [
+                '==',
+                'type',
+                'apron'
+              ]
+            ],
+            'layout': {
+              'visibility': 'visible'
+            },
+            'paint': {
+              'fill-color': 'rgba(221, 221, 221, 1)'
+            }
+          }, {
+            'id': 'landuse_areas_z7',
+            'type': 'fill',
+            'source': 'osm',
+            'source-layer': 'landuse_areas',
+            'minzoom': 7,
+            'maxzoom': 10,
+            'filter': [
+              'all',
+              [
+                'in',
+                'type',
+                'forest',
+                'wood',
+                'nature_reserve'
+              ]
+            ],
+            'layout': {
+              'visibility': 'visible'
+            },
+            'paint': {
+              'fill-color': 'rgba(178, 194, 157, 1)'
+            }
+          }]
+        };
+      });
+
+      it('creates the correct tile grid for vector sources', function(done) {
+        olms(target, context)
+          .then(function(map) {
+            const source = map.getLayers().item(0).getSource();
+            const tileGrid = source.getTileGrid();
+            should(tileGrid.getTileSize()).eql(512);
+            should(tileGrid.getExtent()).eql([-20037508.342789244, -20037471.205137074, 20037508.342789244, 20037471.205137093]);
+            should(tileGrid.getOrigin()).eql([-20037508.342789244, 20037508.342789244]);
+            should(tileGrid.getMinZoom()).eql(0);
+            should(tileGrid.getMaxZoom()).eql(20);
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+
+      it('limits layer minzoom to source minzoom', function(done) {
+        context.sources.osm.minzoom = 8;
+        olms(target, context)
+          .then(function(map) {
+            should(map.getLayers().item(0).getMaxResolution()).eql(defaultResolutions[8] + 1e-9);
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+
+      it('respects layer minzoom and maxzoom', function(done) {
+        olms(target, context)
+          .then(function(map) {
+            should(map.getLayers().item(0).getMaxResolution()).eql(defaultResolutions[7] + 1e-9);
+            should(map.getLayers().item(0).getMinResolution()).eql(defaultResolutions[23] + 1e-9);
             done();
           })
           .catch(function(err) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -173,6 +173,17 @@ describe('ol-mapbox-style', function() {
         });
     });
 
+    it('creates a view with default resolutions', function(done) {
+      olms(target, HotOsm)
+        .then(function(map) {
+          should(map.getView().getResolutions()).eql(defaultResolutions);
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
     describe('raster sources and layers', function() {
 
       let context;

--- a/util.js
+++ b/util.js
@@ -2,6 +2,14 @@ export function deg2rad(degrees) {
   return degrees * Math.PI / 180;
 }
 
+export const defaultResolutions = (function() {
+  const resolutions = [];
+  for (let res = 78271.51696402048; resolutions.length <= 24; res /= 2) {
+    resolutions.push(res);
+  }
+  return resolutions;
+})();
+
 export function getZoomForResolution(resolution, resolutions) {
   let i = 0;
   const ii = resolutions.length;

--- a/webpack.config.olms.js
+++ b/webpack.config.olms.js
@@ -40,6 +40,7 @@ module.exports = {
     'ol/format/GeoJSON': 'ol.format.GeoJSON',
     'ol/format/MVT': 'ol.format.MVT',
     'ol/Map': 'ol.Map',
+    'ol/View': 'ol.View',
     'ol/Observable': 'ol.Observable',
     'ol/layer/Tile': 'ol.layer.Tile',
     'ol/layer/Vector': 'ol.layer.Vector',


### PR DESCRIPTION
Previously `minzoom` and `maxzoom` handling for sources (TileJSON properties) and layers was handled inconsistently. This change makes it so zoom levels for `layers` always refer to mapbox-gl zoom levels and zoom levels for TileJSON refer to zoom levels as defined by the tile size (i.e. the same as mapbox-gl for tile size 512, one off for tile size 256).

When `apply` or the default export are configured with a target element instead of an `ol/Map` instance, the view that ol-mapbox-style creates for the OpenLayers map also has the mapbox-gl resolutions. So `ol/View#getZoom()` will now report the same zoom level as mapbox-gl.

Both changes can be considered breaking changes in some scenarios, so I will bump the major version after this change.