### PR TITLE
Handle fill-outline-color with zero opacity

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -358,7 +358,8 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
             if (color) {
               if ('fill-outline-color' in paint) {
                 strokeColor = colorWithOpacity(getValue(layer, 'paint', 'fill-outline-color', zoom, f), opacity);
-              } else {
+              }
+              if (!strokeColor) {
                 strokeColor = color;
               }
               ++stylesLength;


### PR DESCRIPTION
When a style defines a `fill-outline-color` with a zero opacity, it means that the user wanted to have no outline. So we need to stroke the polygon with the same color as its `fill-color`. This produces less garbage than conditionally creating polygon styles with or without a `Stroke`.