### PR TITLE
Fixed bug in colorCache

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -104,15 +104,14 @@ function colorWithOpacity(color, opacity) {
     if (color.a === 0 || opacity === 0) {
       return undefined;
     }
-    let colorData = colorCache[color];
+    const cache_key = color + '.' + opacity;
+    let colorData = colorCache[cache_key];
     if (!colorData) {
-      colorCache[color] = colorData = {
-        color: color.toArray(),
-        opacity: color.a
-      };
+      colorData = color.toArray();
+      colorData[3] = color.a * opacity;
+      colorCache[cache_key] = colorData;
     }
-    color = colorData.color;
-    color[3] = colorData.opacity * opacity;
+    color = colorData;
   }
   return color;
 }


### PR DESCRIPTION
The bug occur when some features have style with `color : rgb(255, 255, 255)` and `opacity : 1` and other features have style with `color : rgb(255, 255, 255)` and `opacity : 0.5`. They reference same `colorData.color` array. So they make some side effect when features are rendered.