### PR TITLE
Use rgba colors and remove color cache

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -98,21 +98,15 @@ function evaluateFilter(layerId, filter, feature, zoom) {
   return filterCache[layerId](zoomObj, feature);
 }
 
-const colorCache = {};
 function colorWithOpacity(color, opacity) {
-  if (color && opacity !== undefined) {
+  if (color) {
     if (color.a === 0 || opacity === 0) {
       return undefined;
     }
-    let colorData = colorCache[color];
-    if (!colorData) {
-      colorCache[color] = colorData = {
-        color: color.toArray(),
-        opacity: color.a
-      };
-    }
-    color = colorData.color;
-    color[3] = colorData.opacity * opacity;
+    const a = color.a;
+    opacity = opacity === undefined ? 1 : opacity;
+    return 'rgba(' + Math.round(color.r * 255 / a) + ',' + Math.round(color.g * 255 / a) +
+      ',' + Math.round(color.b * 255 / a) + ',' + (a * opacity) + ')';
   }
   return color;
 }

--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -20,8 +20,10 @@ describe('utility functions currently in stylefunction.js', function() {
 
   describe('colorWithOpacity()', function() {
     it('should parse Color instances', function() {
-      should(colorWithOpacity(new Color(1, 0, 0, 1), 1)).eql([255, 0, 0, 1]);
-      should(colorWithOpacity(new Color(1, 0, 0, 1), 0.25)).eql([255, 0, 0, 0.25]);
+      should(colorWithOpacity(new Color(1, 0, 0, 1), 1)).eql('rgba(255,0,0,1)');
+      should(colorWithOpacity(new Color(1, 0, 0, 1), 0.25)).eql('rgba(255,0,0,0.25)');
+      should(colorWithOpacity(new Color(1, 0, 0, 1))).eql('rgba(255,0,0,1)');
+      should(colorWithOpacity(new Color(1, 0, 0, 1))).eql('rgba(255,0,0,1)');
     });
 
     it('should return undefined if alpha or opacity is 0', function() {


### PR DESCRIPTION
By returning color arrays from `colorWithOpacity()`, we forced OpenLayers to do a color translation to rgba, except for icon colors. With this change, OpenLayers can use the colors directly, and we do not need the cache any more.

Replaces and closes #182.