### PR TITLE
Apply default resolutions also when map (but no view) is provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,7 +404,14 @@ function updateRasterLayerProperties(glLayer, layer, view) {
 
 function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
   const promises = [];
-  const view = map.getView();
+  let view = map.getView();
+  if (!view.isDef() && !view.getRotation() && !view.getResolutions()) {
+    view = new View({
+      resolutions: defaultResolutions
+    });
+    map.setView(view);
+  }
+
   if ('center' in glStyle && !view.getCenter()) {
     view.setCenter(fromLonLat(glStyle.center));
   }
@@ -520,10 +527,7 @@ export default function olms(map, style) {
 
   if (!(map instanceof Map)) {
     map = new Map({
-      target: map,
-      view: new View({
-        resolutions: defaultResolutions
-      })
+      target: map
     });
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -185,6 +185,19 @@ describe('ol-mapbox-style', function() {
         });
     });
 
+    it('creates a view with default resolutions for a map with an undefined view', function(done) {
+      olms(new Map({
+        target: target
+      }), './fixtures/hot-osm/hot-osm.json')
+        .then(function(map) {
+          should(map.getView().getResolutions()).eql(defaultResolutions);
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
     describe('raster sources and layers', function() {
 
       let context;


### PR DESCRIPTION
This pull request simplifies configuration when users want to create a custom map, but want ol-mapbox-style to be responsible for the view. For maps configured without a view, ol-mapbox-style will now replace the default view with a view with the correct resolutions, and apply center and zoom to it as if no map was provided.