### PR TITLE
Reduce max-angle when hairspaces are used

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -574,7 +574,7 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
             }
             text.setTextAlign(textAlign);
           } else {
-            text.setMaxAngle(deg2rad(getValue(layer, 'layout', 'text-max-angle', zoom, f)));
+            text.setMaxAngle(deg2rad(getValue(layer, 'layout', 'text-max-angle', zoom, f)) * label.length / wrappedLabel.length);
             text.setTextAlign();
           }
           let textBaseline = 'middle';


### PR DESCRIPTION
When `text-letter-spacing` is set for a text, we use hair spaces to widen the text. This can cause sharp turns in text along lines. This pull request removes this effect by dividing the original label width by the label width after the hair spaces are applied.
 
Fixes #186.