### PR TITLE
Only include style spec once

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -12,10 +12,10 @@ import Text from 'ol/style/Text';
 import Circle from 'ol/style/Circle';
 import RenderFeature from 'ol/render/Feature';
 import derefLayers from '@mapbox/mapbox-gl-style-spec/deref';
-import spec from '@mapbox/mapbox-gl-style-spec/reference/latest';
 import {
   expression, Color,
   function as fn,
+  latest as spec,
   featureFilter as createFilter
 } from '@mapbox/mapbox-gl-style-spec';
 import mb2css from 'mapbox-to-css-font';

--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -2,8 +2,7 @@
 import should from 'should';
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
-import {Color} from '@mapbox/mapbox-gl-style-spec';
-import spec from '@mapbox/mapbox-gl-style-spec/reference/latest';
+import {Color, latest as spec} from '@mapbox/mapbox-gl-style-spec';
 
 
 import {


### PR DESCRIPTION
This pull request changes the style spec import to import directly from the main module. As a result, the build size of bundles is reduced by about 90kB.