### PR TITLE
Round text size to integer pixels

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -545,7 +545,7 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
             }));
           }
           text = style.getText();
-          const textSize = getValue(layer, 'layout', 'text-size', zoom, f);
+          const textSize = Math.round(getValue(layer, 'layout', 'text-size', zoom, f));
           const fontArray = getValue(layer, 'layout', 'text-font', zoom, f);
           const textLineHeight = getValue(layer, 'layout', 'text-line-height', zoom, f);
           const font = mb2css(getFonts ? getFonts(fontArray) : fontArray, textSize, textLineHeight);


### PR DESCRIPTION
This pull request reduces pressure on OpenLayers's font cache: `CanvasRenderingContext2D` can only handle integer font sizes in pixels, so it makes no sense to use fractional font sizes.