### PR TITLE
Fix Google fonts name parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function getFonts(fonts) {
   }
   const googleFontDescriptions = fonts.map(function(font) {
     const parts = mb2css(font, 1).split(' ');
-    return [parts.slice(3, 5).join(' ').replace(/"/g, ''), parts[1] + parts[0]];
+    return [parts.slice(3).join(' ').replace(/"/g, ''), parts[1] + parts[0]];
   });
   for (let i = 0, ii = googleFontDescriptions.length; i < ii; ++i) {
     const googleFontDescription = googleFontDescriptions[i];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -498,16 +498,17 @@ describe('ol-mapbox-style', function() {
 
     it('loads fonts from fonts.google.com', function() {
       let stylesheets;
-      getFonts(['Noto Sans Bold', 'Noto Sans Regular Italic']);
+      getFonts(['Noto Sans Bold', 'Noto Sans Regular Italic', 'Averia Sans Libre Bold']);
       stylesheets = document.querySelectorAll('link[rel=stylesheet]');
-      should(stylesheets.length).eql(2);
+      should(stylesheets.length).eql(3);
       should(stylesheets.item(0).href).eql('https://fonts.googleapis.com/css?family=Noto+Sans:700normal');
       should(stylesheets.item(1).href).eql('https://fonts.googleapis.com/css?family=Noto+Sans:400italic');
+      should(stylesheets.item(2).href).eql('https://fonts.googleapis.com/css?family=Averia+Sans+Libre:700normal');
 
       // already loaded family, no additional link
       getFonts(['Noto Sans Bold']);
       stylesheets = document.querySelectorAll('link[rel=stylesheet]');
-      should(stylesheets.length).eql(2);
+      should(stylesheets.length).eql(3);
     });
   });
 });


### PR DESCRIPTION
The font name was not correctly parsed if it contains more than two 'words'.