### PR TITLE
Use TypeScript for type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,22 +66,26 @@ fetch('data/states.json').then(function(response) {
 
 -   [applyStyle](#applystyle)
     -   [Parameters](#parameters)
--   [applyBackground](#applybackground)
-    -   [Parameters](#parameters-1)
--   [olms](#olms)
-    -   [Parameters](#parameters-2)
--   [apply](#apply)
-    -   [Parameters](#parameters-3)
--   [getLayer](#getlayer)
-    -   [Parameters](#parameters-4)
--   [getLayers](#getlayers)
-    -   [Parameters](#parameters-5)
--   [getSource](#getsource)
-    -   [Parameters](#parameters-6)
 -   [stylefunction](#stylefunction)
+    -   [Parameters](#parameters-1)
+-   [applyBackground](#applybackground)
+    -   [Parameters](#parameters-2)
+-   [olms](#olms)
+    -   [Parameters](#parameters-3)
+-   [apply](#apply)
+    -   [Parameters](#parameters-4)
+-   [getLayer](#getlayer)
+    -   [Parameters](#parameters-5)
+-   [getLayers](#getlayers)
+    -   [Parameters](#parameters-6)
+-   [getSource](#getsource)
     -   [Parameters](#parameters-7)
 
 ### applyStyle
+
+```js
+import {applyStyle} from 'ol-mapbox-style';
+```
 
 Applies a style function to an `ol.layer.VectorTile` or `ol.layer.Vector`
 with an `ol.source.VectorTile` or an `ol.source.Vector`. The style function
@@ -100,7 +104,7 @@ Two additional properties will be set on the provided layer:
 
 #### Parameters
 
--   `layer` **(ol.layer.VectorTile | ol.layer.Vector)** OpenLayers layer.
+-   `layer` **(VectorTileLayer | VectorLayer)** OpenLayers layer.
 -   `glStyle` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))** Mapbox Style object.
 -   `source` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** `source` key or an array of layer `id`s from the
     Mapbox Style object. When a `source` key is provided, all layers for the
@@ -113,6 +117,58 @@ Two additional properties will be set on the provided layer:
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Promise which will be resolved when the style can be used
 for rendering.
 
+### stylefunction
+
+```js
+import stylefunction from 'ol-mapbox-style/stylefunction';
+```
+
+Creates a style function from the `glStyle` object for all layers that use
+the specified `source`, which needs to be a `"type": "vector"` or
+`"type": "geojson"` source and applies it to the specified OpenLayers layer.
+
+Two additional properties will be set on the provided layer:
+
+-   `mapbox-source`: The `id` of the Mapbox Style document's source that the
+    OpenLayers layer was created from. Usually `apply()` creates one
+    OpenLayers layer per Mapbox Style source, unless the layer stack has
+    layers from different sources in between.
+-   `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
+    included in the OpenLayers layer.
+
+#### Parameters
+
+-   `olLayer` **(VectorLayer | VectorTileLayer)** OpenLayers layer to
+    apply the style to. In addition to the style, the layer will get two
+    properties: `mapbox-source` will be the `id` of the `glStyle`'s source used
+    for the layer, and `mapbox-layers` will be an array of the `id`s of the
+    `glStyle`'s layers.
+-   `glStyle` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))** Mapbox Style object.
+-   `source` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** `source` key or an array of layer `id`s
+    from the Mapbox Style object. When a `source` key is provided, all layers for
+    the specified source will be included in the style function. When layer `id`s
+    are provided, they must be from layers that use the same source.
+-   `resolutions` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Resolutions for mapping resolution to zoom level. (optional, default `[78271.51696402048,39135.75848201024,
+    19567.87924100512,9783.93962050256,4891.96981025128,2445.98490512564,
+    1222.99245256282,611.49622628141,305.748113140705,152.8740565703525,
+    76.43702828517625,38.21851414258813,19.109257071294063,9.554628535647032,
+    4.777314267823516,2.388657133911758,1.194328566955879,0.5971642834779395,
+    0.29858214173896974,0.14929107086948487,0.07464553543474244]`)
+-   `spriteData` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Sprite data from the url specified in
+    the Mapbox Style object's `sprite` property. Only required if a `sprite`
+    property is specified in the Mapbox Style object. (optional, default `undefined`)
+-   `spriteImageUrl` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Sprite image url for the sprite
+    specified in the Mapbox Style object's `sprite` property. Only required if a
+    `sprite` property is specified in the Mapbox Style object. (optional, default `undefined`)
+-   `getFonts` **function ([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>): [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** Function that
+    receives a font stack as arguments, and returns a (modified) font stack that
+    is available. Font names are the names used in the Mapbox Style object. If
+    not provided, the font stack will be used as-is. This function can also be
+    used for loading web fonts. (optional, default `undefined`)
+
+Returns **StyleFunction** Style function for use in
+`ol.layer.Vector` or `ol.layer.VectorTile`.
+
 ### applyBackground
 
 ```js
@@ -123,7 +179,7 @@ Applies properties of the Mapbox Style's first `background` layer to the map.
 
 #### Parameters
 
--   `map` **ol.Map** OpenLayers Map.
+-   `map` **PluggableMap** OpenLayers Map.
 -   `glStyle` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Mapbox Style object.
 
 ### olms
@@ -155,7 +211,7 @@ map instance, which holds the Mapbox Style object.
 
 #### Parameters
 
--   `map` **(ol.Map | [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Either an existing OpenLayers Map
+-   `map` **(PluggableMap | [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Either an existing OpenLayers Map
     instance, or a HTML element, or the id of a HTML element that will be the
     target of a new OpenLayers Map.
 -   `style` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))** JSON style object or style url pointing to a
@@ -179,11 +235,11 @@ argument.
 import {apply} from 'ol-mapbox-style';
 ```
 
-Like `olms`, but returns an `ol.Map` instance instead of a `Promise`.
+Like `olms`, but returns an `ol/Map` instance instead of a `Promise`.
 
 #### Parameters
 
--   `map` **(ol.Map | [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Either an existing OpenLayers Map
+-   `map` **(PluggableMap | [HTMLElement](https://developer.mozilla.org/docs/Web/HTML/Element) \| [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Either an existing OpenLayers Map
     instance, or a HTML element, or the id of a HTML element that will be the
     target of a new OpenLayers Map.
 -   `style` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))** JSON style object or style url pointing to a
@@ -196,7 +252,7 @@ Like `olms`, but returns an `ol.Map` instance instead of a `Promise`.
     as style url, layers will be added to the map when the Mapbox Style document
     is loaded and parsed.
 
-Returns **ol.Map** The OpenLayers Map instance that will be populated with the
+Returns **PluggableMap** The OpenLayers Map instance that will be populated with the
 contents described in the Mapbox Style object.
 
 ### getLayer
@@ -211,10 +267,10 @@ OpenLayers layer instance when they use the same Mapbox Style `source`.
 
 #### Parameters
 
--   `map` **ol.Map** OpenLayers Map.
+-   `map` **PluggableMap** OpenLayers Map.
 -   `layerId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Mapbox Style layer id.
 
-Returns **ol.layer.Layer** OpenLayers layer instance.
+Returns **Layer** OpenLayers layer instance.
 
 ### getLayers
 
@@ -226,10 +282,10 @@ Get the OpenLayers layer instances for the provided Mapbox Style `source`.
 
 #### Parameters
 
--   `map` **ol.Map** OpenLayers Map.
+-   `map` **PluggableMap** OpenLayers Map.
 -   `sourceId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Mapbox Style source id.
 
-Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;ol.layer.Layer>** OpenLayers layer instances.
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Layer>** OpenLayers layer instances.
 
 ### getSource
 
@@ -241,62 +297,10 @@ Get the OpenLayers source instance for the provided Mapbox Style `source`.
 
 #### Parameters
 
--   `map` **ol.Map** OpenLayers Map.
+-   `map` **PluggableMap** OpenLayers Map.
 -   `sourceId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Mapbox Style source id.
 
-Returns **ol.source.Source** OpenLayers source instance.
-
-### stylefunction
-
-```js
-import stylefunction from 'ol-mapbox-style/stylefunction';
-```
-
-Creates a style function from the `glStyle` object for all layers that use
-the specified `source`, which needs to be a `"type": "vector"` or
-`"type": "geojson"` source and applies it to the specified OpenLayers layer.
-
-Two additional properties will be set on the provided layer:
-
--   `mapbox-source`: The `id` of the Mapbox Style document's source that the
-    OpenLayers layer was created from. Usually `apply()` creates one
-    OpenLayers layer per Mapbox Style source, unless the layer stack has
-    layers from different sources in between.
--   `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
-    included in the OpenLayers layer.
-
-#### Parameters
-
--   `olLayer` **(ol.layer.Vector | ol.layer.VectorTile)** OpenLayers layer to
-    apply the style to. In addition to the style, the layer will get two
-    properties: `mapbox-source` will be the `id` of the `glStyle`'s source used
-    for the layer, and `mapbox-layers` will be an array of the `id`s of the
-    `glStyle`'s layers.
--   `glStyle` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))** Mapbox Style object.
--   `source` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** `source` key or an array of layer `id`s
-    from the Mapbox Style object. When a `source` key is provided, all layers for
-    the specified source will be included in the style function. When layer `id`s
-    are provided, they must be from layers that use the same source.
--   `resolutions` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Resolutions for mapping resolution to zoom level. (optional, default `[78271.51696402048,39135.75848201024,
-    19567.87924100512,9783.93962050256,4891.96981025128,2445.98490512564,
-    1222.99245256282,611.49622628141,305.748113140705,152.8740565703525,
-    76.43702828517625,38.21851414258813,19.109257071294063,9.554628535647032,
-    4.777314267823516,2.388657133911758,1.194328566955879,0.5971642834779395,
-    0.29858214173896974,0.14929107086948487,0.07464553543474244]`)
--   `spriteData` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Sprite data from the url specified in
-    the Mapbox Style object's `sprite` property. Only required if a `sprite`
-    property is specified in the Mapbox Style object. (optional, default `undefined`)
--   `spriteImageUrl` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Sprite image url for the sprite
-    specified in the Mapbox Style object's `sprite` property. Only required if a
-    `sprite` property is specified in the Mapbox Style object. (optional, default `undefined`)
--   `getFonts` **function ([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>): [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** Function that
-    receives a font stack as arguments, and returns a (modified) font stack that
-    is available. Font names are the names used in the Mapbox Style object. If
-    not provided, the font stack will be used as-is. This function can also be
-    used for loading web fonts. (optional, default `undefined`)
-
-Returns **ol.style.StyleFunction** Style function for use in
-`ol.layer.Vector` or `ol.layer.VectorTile`.
+Returns **Source** OpenLayers source instance.
 
 ## Building the library
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "baseUrl": "./",
+    "paths": {
+      "ol": ["node_modules/ol/src"],
+      "ol/*": ["node_modules/ol/src/*"]
+    },
+    "lib": [
+      "es2015",
+      "dom"
+    ]
+  },
+  "include": [
+    "*.js",
+    "node_modules/ol/**/*.js"
+  ]
+}

--- a/olms.js
+++ b/olms.js
@@ -1,9 +1,10 @@
 import olms, {apply, applyBackground, applyStyle} from './index';
 import stylefunction from './stylefunction';
 
-olms.apply = apply;
-olms.applyBackground = applyBackground;
-olms.applyStyle = applyStyle;
-olms.stylefunction = stylefunction;
+const exports = /** @type {Object} */ (olms);
+exports.apply = apply;
+exports.applyBackground = applyBackground;
+exports.applyStyle = applyStyle;
+exports.stylefunction = stylefunction;
 
-export default olms;
+export default exports;

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "start": "webpack-dev-server --config ./webpack.config.js",
     "prepare": "npm run doc && npm run build",
     "build": "webpack-cli --mode=production --config ./webpack.config.olms.js && webpack-cli --mode=production",
-    "doc": "documentation readme -s API index.js",
+    "doc": "documentation readme -s API index.js stylefunction.js --document-exported true",
     "karma": "karma start test/karma.conf.js",
     "lint": "eslint test example *.js",
-    "pretest": "npm run lint",
+    "typecheck": "tsc --project tsconfig-typecheck.json",
+    "pretest": "npm run lint && npm run typecheck",
     "test": "npm run karma -- --single-run --log-level error"
   },
   "dependencies": {
@@ -35,13 +36,14 @@
     "ol": "^6.0.0-beta.7"
   },
   "devDependencies": {
+    "@types/node": "^12.0.8",
     "babel-loader": "^8.0.5",
     "buble": "^0.19.6",
     "buble-loader": "^0.5.1",
     "copy-webpack-plugin": "^4.6.0",
     "css-loader": "^1.0.1",
     "deep-freeze": "0.0.1",
-    "documentation": "^9.1.1",
+    "documentation": "^11.0.1",
     "eslint": "^5.13.0",
     "eslint-config-openlayers": "^11.0.0",
     "html-webpack-plugin": "^3.2.0",
@@ -54,11 +56,12 @@
     "mapbox-gl-styles": "^2.0.2",
     "mini-css-extract-plugin": "^0.4.5",
     "mocha": "^5.2.0",
-    "ol": "^6.0.0-beta.7",
+    "ol": "^6.0.0-beta.8",
     "puppeteer": "^1.12.2",
     "should": "^13.2.3",
     "sinon": "^7.2.3",
     "style-loader": "^0.23.1",
+    "typescript": "^3.5.2",
     "webpack": "^4.29.3",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.1.14"

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -21,6 +21,12 @@ import {
 import mb2css from 'mapbox-to-css-font';
 import {deg2rad, defaultResolutions, getZoomForResolution, wrapText, applyLetterSpacing} from './util';
 
+/**
+ * @typedef {import("ol/layer/Vector").default} VectorLayer
+ * @typedef {import("ol/layer/VectorTile").default} VectorTileLayer
+ * @typedef {import("ol/style/Style").StyleFunction} StyleFunction
+ */
+
 const isFunction = fn.isFunction;
 const convertFunction = fn.convertFunction;
 const isExpression = expression.isExpression;
@@ -56,6 +62,7 @@ const expressionData = function(rawExpression, propertySpec) {
 
 const emptyObj = {};
 const zoomObj = {zoom: 0};
+/** @private */
 const functionCache = {};
 let renderFeatureCoordinates, renderFeature;
 
@@ -101,7 +108,17 @@ export function getValue(layer, layoutOrPaint, property, zoom, feature) {
   return functions[property](zoomObj, feature);
 }
 
+/** @private */
 const filterCache = {};
+
+/**
+ * @private
+ * @param {string} layerId Layer id.
+ * @param {?} filter Filter.
+ * @param {Object} feature Feature.
+ * @param {number} zoom Zoom.
+ * @return {boolean} Filter result.
+ */
 function evaluateFilter(layerId, filter, feature, zoom) {
   if (!(layerId in filterCache)) {
     filterCache[layerId] = createFilter(filter);
@@ -110,6 +127,12 @@ function evaluateFilter(layerId, filter, feature, zoom) {
   return filterCache[layerId](zoomObj, feature);
 }
 
+/**
+ * @private
+ * @param {?} color Color.
+ * @param {number} opacity Opacity.
+ * @return {string} Color.
+ */
 function colorWithOpacity(color, opacity) {
   if (color) {
     if (color.a === 0 || opacity === 0) {
@@ -124,6 +147,13 @@ function colorWithOpacity(color, opacity) {
 }
 
 const templateRegEx = /^([^]*)\{(.*)\}([^]*)$/;
+
+/**
+ * @private
+ * @param {string} text Text.
+ * @param {Object} properties Properties.
+ * @return {string} Text.
+ */
 function fromTemplate(text, properties) {
   let parts;
   do {
@@ -153,7 +183,7 @@ function fromTemplate(text, properties) {
  *  * `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
  *    included in the OpenLayers layer.
  *
- * @param {ol.layer.Vector|ol.layer.VectorTile} olLayer OpenLayers layer to
+ * @param {VectorLayer|VectorTileLayer} olLayer OpenLayers layer to
  * apply the style to. In addition to the style, the layer will get two
  * properties: `mapbox-source` will be the `id` of the `glStyle`'s source used
  * for the layer, and `mapbox-layers` will be an array of the `id`s of the
@@ -164,11 +194,11 @@ function fromTemplate(text, properties) {
  * the specified source will be included in the style function. When layer `id`s
  * are provided, they must be from layers that use the same source.
  * @param {Array<number>} [resolutions=[78271.51696402048, 39135.75848201024,
- * 19567.87924100512, 9783.93962050256, 4891.96981025128, 2445.98490512564,
- * 1222.99245256282, 611.49622628141, 305.748113140705, 152.8740565703525,
- * 76.43702828517625, 38.21851414258813, 19.109257071294063, 9.554628535647032,
- * 4.777314267823516, 2.388657133911758, 1.194328566955879, 0.5971642834779395,
- * 0.29858214173896974, 0.14929107086948487, 0.07464553543474244]]
+   19567.87924100512, 9783.93962050256, 4891.96981025128, 2445.98490512564,
+   1222.99245256282, 611.49622628141, 305.748113140705, 152.8740565703525,
+   76.43702828517625, 38.21851414258813, 19.109257071294063, 9.554628535647032,
+   4.777314267823516, 2.388657133911758, 1.194328566955879, 0.5971642834779395,
+   0.29858214173896974, 0.14929107086948487, 0.07464553543474244]]
  * Resolutions for mapping resolution to zoom level.
  * @param {Object} [spriteData=undefined] Sprite data from the url specified in
  * the Mapbox Style object's `sprite` property. Only required if a `sprite`
@@ -181,7 +211,7 @@ function fromTemplate(text, properties) {
  * is available. Font names are the names used in the Mapbox Style object. If
  * not provided, the font stack will be used as-is. This function can also be
  * used for loading web fonts.
- * @return {ol.style.StyleFunction} Style function for use in
+ * @return {StyleFunction} Style function for use in
  * `ol.layer.Vector` or `ol.layer.VectorTile`.
  */
 export default function(olLayer, glStyle, source, resolutions = defaultResolutions, spriteData, spriteImageUrl, getFonts) {

--- a/tsconfig-typecheck.json
+++ b/tsconfig-typecheck.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "baseUrl": "./",
+    "paths": {
+      "ol": ["node_modules/ol/src"],
+      "ol/*": ["node_modules/ol/src/*"]
+    },
+    "lib": [
+      "es2015",
+      "dom"
+    ]
+  },
+  "include": [
+    "*.js"
+  ]
+}

--- a/util.js
+++ b/util.js
@@ -44,7 +44,7 @@ export function applyLetterSpacing(text, letterSpacing) {
   return text;
 }
 
-const ctx = document.createElement('CANVAS').getContext('2d');
+const ctx = /** @type {HTMLCanvasElement} */ (document.createElement('CANVAS')).getContext('2d');
 function measureText(text, letterSpacing) {
   return ctx.measureText(text).width + (text.length - 1) * letterSpacing;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
  *  @param {String} dirName - Name of the directory to read.
  *  @param {Function} callback - Function to execute for each example.
  *
- *  @returns {undefined} Nothing.
+ *  @returns {Object} Entries.
  */
 function getExamples(dirName, callback) {
   const example_files = fs.readdirSync(dirName);


### PR DESCRIPTION
This pull request brings in the TypeScript compiler for type checking. It also adds a `jsconfig.json` for making IntelliSense work with the OpenLayers dependency.