### PR TITLE
Set maxResolution on view

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,7 +438,7 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken) {
   let view = map.getView();
   if (!view.isDef() && !view.getRotation() && !view.getResolutions()) {
     view = new View({
-      resolutions: defaultResolutions
+      maxResolution: defaultResolutions[0]
     });
     map.setView(view);
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -177,7 +177,7 @@ describe('ol-mapbox-style', function() {
     it('creates a view with default resolutions', function(done) {
       olms(target, './fixtures/hot-osm/hot-osm.json')
         .then(function(map) {
-          should(map.getView().getResolutions()).eql(defaultResolutions);
+          should(map.getView().getMaxResolution()).eql(defaultResolutions[0]);
           done();
         })
         .catch(function(err) {
@@ -190,7 +190,7 @@ describe('ol-mapbox-style', function() {
         target: target
       }), './fixtures/hot-osm/hot-osm.json')
         .then(function(map) {
-          should(map.getView().getResolutions()).eql(defaultResolutions);
+          should(map.getView().getMaxResolution()).eql(defaultResolutions[0]);
           done();
         })
         .catch(function(err) {


### PR DESCRIPTION
Currently we configure a view with `resolutions`. By changing that so we configure `maxResolution` instead, we get the correct zoom levels for 512px tiles *and* a view that never shows more than one world.