### PR TITLE
Fix fromTemplate errors by only passing in Strings

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -316,7 +316,7 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
           if ('fill-pattern' in paint) {
             const fillIcon = getValue(layer, 'paint', 'fill-pattern', zoom, f);
             if (fillIcon) {
-              const icon = fromTemplate(fillIcon, properties);
+              const icon = fromTemplate(fillIcon.toString(), properties);
               if (spriteImage && spriteData && spriteData[icon]) {
                 ++stylesLength;
                 style = styles[stylesLength];
@@ -413,7 +413,7 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
         if ((type == 1 || type == 2) && 'icon-image' in layout) {
           const iconImage = getValue(layer, 'layout', 'icon-image', zoom, f);
           if (iconImage) {
-            icon = fromTemplate(iconImage, properties);
+            icon = fromTemplate(iconImage.toString(), properties);
             let styleGeom = undefined;
             if (spriteImage && spriteData && spriteData[icon]) {
               const iconRotationAlignment = getValue(layer, 'layout', 'icon-rotation-alignment', zoom, f);

--- a/stylefunction.js
+++ b/stylefunction.js
@@ -316,7 +316,9 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
           if ('fill-pattern' in paint) {
             const fillIcon = getValue(layer, 'paint', 'fill-pattern', zoom, f);
             if (fillIcon) {
-              const icon = fromTemplate(fillIcon.toString(), properties);
+              const icon = typeof fillIcon === 'string'
+                ? fromTemplate(fillIcon, properties)
+                : fillIcon.toString();
               if (spriteImage && spriteData && spriteData[icon]) {
                 ++stylesLength;
                 style = styles[stylesLength];
@@ -413,7 +415,9 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
         if ((type == 1 || type == 2) && 'icon-image' in layout) {
           const iconImage = getValue(layer, 'layout', 'icon-image', zoom, f);
           if (iconImage) {
-            icon = fromTemplate(iconImage.toString(), properties);
+            icon = typeof iconImage === 'string'
+              ? fromTemplate(iconImage, properties)
+              : iconImage.toString();
             let styleGeom = undefined;
             if (spriteImage && spriteData && spriteData[icon]) {
               const iconRotationAlignment = getValue(layer, 'layout', 'icon-rotation-alignment', zoom, f);


### PR DESCRIPTION
Objects like `ResolvedImage` can result from `getValue`.
Stringify all return values from `getValue` before passing them to `fromTemplate` to prevent runtime errors.