### PR TITLE
Fix undefined line concatenation in wrapText util

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -86,7 +86,7 @@ export function wrapText(text, font, em, letterSpacing) {
       // Pass 2 - add lines with a width of less than 30% of maxWidth to the previous or next line
       for (let i = 0, ii = lines.length; i < ii; ++i) {
         const line = lines[i];
-        if (measureText(line, letterSpacing) < maxWidth * 0.35) {
+        if ((measureText(line, letterSpacing) < maxWidth * 0.35) && (lines[i + 1] !== undefined)) {
           const prevWidth = i > 0 ? measureText(lines[i - 1], letterSpacing) : Infinity;
           const nextWidth = i < ii - 1 ? measureText(lines[i + 1], letterSpacing) : Infinity;
           lines.splice(i, 1);

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,20 @@
+import should from 'should';
+import {wrapText} from '../src/util';
+
+describe('util', function() {
+
+  describe('wrapText()', function() {
+
+    it('should not combine undefined when no next line exists', function() {
+      const text = 'Shor T';
+      const result = wrapText(text, 'normal 600 12px/1.2 "Open Sans"', 10, 0);
+      should(result).equal(text);
+    });
+
+    it('should wrap text', function() {
+      const text = 'Longer line of text for wrapping';
+      const result = wrapText(text, 'normal 600 12px/1.2 "Open Sans"', 10, 0);
+      result.includes('\n').should.be.true();
+    });
+  });
+});


### PR DESCRIPTION
Fix for issue #249 

When text is less than 30% and contains multiple words, `wrapText()` will attempt to append a next line, even if it does not exist. This PR adds a check to make sure there is a next line before combining.