### PR TITLE
Preserve hard line breaks when wrapping text

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -57,6 +57,14 @@ if (labelCache) {
   });
 }
 export function wrapText(text, font, em, letterSpacing) {
+  if (text.indexOf('\n') !== -1) {
+    const hardLines = text.split('\n');
+    const lines = [];
+    for (let i = 0, ii = hardLines.length; i < ii; ++i) {
+      lines.push(wrapText(hardLines[i], font, em, letterSpacing));
+    }
+    return lines.join('\n');
+  }
   const key = em + ',' + font + ',' + text + ',' + letterSpacing;
   let wrappedText = measureCache[key];
   if (!wrappedText) {
@@ -84,11 +92,11 @@ export function wrapText(text, font, em, letterSpacing) {
         lines.push(line);
       }
       // Pass 2 - add lines with a width of less than 30% of maxWidth to the previous or next line
-      for (let i = 0, ii = lines.length; i < ii; ++i) {
+      for (let i = 0; i < lines.length; ++i) {
         const line = lines[i];
-        if ((measureText(line, letterSpacing) < maxWidth * 0.35) && (lines[i + 1] !== undefined)) {
+        if (measureText(line, letterSpacing) < maxWidth * 0.35) {
           const prevWidth = i > 0 ? measureText(lines[i - 1], letterSpacing) : Infinity;
-          const nextWidth = i < ii - 1 ? measureText(lines[i + 1], letterSpacing) : Infinity;
+          const nextWidth = i < lines.length - 1 ? measureText(lines[i + 1], letterSpacing) : Infinity;
           lines.splice(i, 1);
           if (prevWidth < nextWidth) {
             lines[i - 1] += ' ' + line;
@@ -96,7 +104,7 @@ export function wrapText(text, font, em, letterSpacing) {
           } else {
             lines[i] = line + ' ' + lines[i];
           }
-          ii -= 1;
+          lines.length -= 1;
         }
       }
       // Pass 3 - try to fill 80% of maxWidth for each line

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -7,14 +7,20 @@ describe('util', function() {
 
     it('should not combine undefined when no next line exists', function() {
       const text = 'Shor T';
-      const result = wrapText(text, 'normal 600 12px/1.2 "Open Sans"', 10, 0);
+      const result = wrapText(text, 'normal 400 12px/1.2 sans-serif', 10, 0);
       should(result).equal(text);
     });
 
     it('should wrap text', function() {
       const text = 'Longer line of text for wrapping';
-      const result = wrapText(text, 'normal 600 12px/1.2 "Open Sans"', 10, 0);
+      const result = wrapText(text, 'normal 400 12px/1.2 sans-serif', 10, 0);
       result.includes('\n').should.be.true();
+    });
+
+    it('should preserve hard breaks', function() {
+      const text = 'Großer Sonnleitstein\n1639 m';
+      const result = wrapText(text, 'normal 400 12px/1.2 sans-serif', 10, 0);
+      should(result).equal('Großer\nSonnleitstein\n1639 m');
     });
   });
 });


### PR DESCRIPTION
This pull request fixes an issue that was introduced with #256, and changes `wrapText` so it preserves hard line breaks.