### PR TITLE
Use first flatMidpoints when labeling MultiLineString features

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -461,7 +461,7 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
               if (type == 2) {
                 const geom = feature.getGeometry();
                 // ol package and ol-debug.js only
-                if (geom.getFlatMidpoint) {
+                if (geom.getFlatMidpoint || geom.getFlatMidpoints) {
                   const extent = geom.getExtent();
                   const size = Math.sqrt(Math.max(
                     Math.pow((extent[2] - extent[0]) / resolution, 2),
@@ -469,7 +469,7 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
                   );
                   if (size > 150) {
                     //FIXME Do not hard-code a size of 150
-                    const midpoint = geom.getFlatMidpoint();
+                    const midpoint = geom.getType() === 'MultiLineString' ? geom.getFlatMidpoints() : geom.getFlatMidpoint();
                     if (!renderFeature) {
                       renderFeatureCoordinates = [NaN, NaN];
                       renderFeature = new RenderFeature('Point', renderFeatureCoordinates, [], {}, null);


### PR DESCRIPTION
This modifies the label midpoint to use the first midpoint for a MultiLineString and retains the existing functionality for LineString features.

This is the solution proposed in #95 to improve the labeling for MultiLineString features.

> To improve the situation, the easiest solution is to use getFlatMidpoint for LineString geometries and getFlatMidpoints with only the first midpoint for MultiLineString geometries. Anyone willing to provide a pull request?