### PR TITLE
Fix removing too many lines when combining wrapped lines

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -128,7 +128,6 @@ export function wrapText(text, font, em, letterSpacing) {
           } else {
             lines[i] = line + ' ' + lines[i];
           }
-          lines.length -= 1;
         }
       }
       // Pass 3 - try to fill 80% of maxWidth for each line

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -22,5 +22,11 @@ describe('util', function() {
       const result = wrapText(text, 'normal 400 12px/1.2 sans-serif', 10, 0);
       should(result).equal('Großer\nSonnleitstein\n1639 m');
     });
+
+    it('should combine lines with less than 30% max width', function() {
+      const text = 'Single_Long_Word 30%';
+      const result = wrapText(text, 'normal 400 12px/1.2 sans-serif', 10, 0);
+      should(result).equal(text);
+    });
   });
 });


### PR DESCRIPTION
Splicing on line 124 will update the array length. The additional decrement of length causes a bug where less than expected number wrapped lines will show. If the correct length is 1, this will even cause the label to not appear at all.