### PR TITLE
Make compatible with polyfill requirements for OpenLayers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ fetch('data/states.json').then(function(response) {
 Internet Explorer (version 11) and other old browsers (Android 4.x) are supported when polyfills for the following features are loaded:
 
 -   `fetch` (including `Promise`)
--   `String.prototype.startsWith`
--   `Object.assign`
 
 ### Webpack
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import Map from 'ol/Map';
 import View from 'ol/View';
 import GeoJSON from 'ol/format/GeoJSON';
 import MVT from 'ol/format/MVT';
+import {assign} from 'ol/obj';
 import {unByKey} from 'ol/Observable';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
@@ -98,7 +99,7 @@ function getFonts(fonts) {
 const spriteRegEx = /^(.*)(\?.*)$/;
 
 function withPath(url, path) {
-  if (path && url.startsWith('.')) {
+  if (path && url.indexOf('.') === 0) {
     url = path + url;
   }
   return url;
@@ -288,7 +289,7 @@ function extentFromTileJSON(tileJSON) {
 }
 
 function setupVectorLayer(glSource, accessToken, url) {
-  glSource = Object.assign({}, glSource);
+  glSource = assign({}, glSource);
   const layer = new VectorTileLayer({
     declutter: true,
     visible: false

--- a/src/olms.js
+++ b/src/olms.js
@@ -1,6 +1,7 @@
 import olms, {apply, applyBackground, applyStyle} from './index';
 import stylefunction from './stylefunction';
+import {assign} from 'ol/obj';
 
-Object.assign(olms, {apply, applyBackground, applyStyle, stylefunction});
+assign(olms, {apply, applyBackground, applyStyle, stylefunction});
 
 export default olms;

--- a/webpack.config.olms.js
+++ b/webpack.config.olms.js
@@ -13,6 +13,7 @@ const externals = {
   'ol/format/MVT': 'ol.format.MVT',
   'ol/Map': 'ol.Map',
   'ol/View': 'ol.View',
+  'ol/obj': 'ol.obj',
   'ol/Observable': 'ol.Observable',
   'ol/layer/Tile': 'ol.layer.Tile',
   'ol/layer/Vector': 'ol.layer.Vector',


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/11103

Currently polyfills for Object.assign and String.prototype.startsWith are needed to use ol-mapbox-style on older browsers in addition to those required by OpenLayers.  olms already imports  `ol/obj#assign` via VectorLayer and VectorTileLayer and https://www.measurethat.net/Benchmarks/ListResults/3417 shows there is little if any performance advantage in using startsWith over indexOf for a single character on most browsers, and on Chrome it is considerably slower.