### PR TITLE
Fix undefined appended for single line < 35% width

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -147,17 +147,20 @@ export function wrapText(text, font, em, letterSpacing) {
         lines.push(line);
       }
       // Pass 2 - add lines with a width of less than 30% of maxWidth to the previous or next line
-      for (let i = 0; i < lines.length; ++i) {
-        const line = lines[i];
-        if (measureText(line, letterSpacing) < maxWidth * 0.35) {
-          const prevWidth = i > 0 ? measureText(lines[i - 1], letterSpacing) : Infinity;
-          const nextWidth = i < lines.length - 1 ? measureText(lines[i + 1], letterSpacing) : Infinity;
-          lines.splice(i, 1);
-          if (prevWidth < nextWidth) {
-            lines[i - 1] += ' ' + line;
-            i -= 1;
-          } else {
-            lines[i] = line + ' ' + lines[i];
+      if (lines.length > 1) {
+        for (let i = 0, ii = lines.length; i < ii; ++i) {
+          const line = lines[i];
+          if (measureText(line, letterSpacing) < maxWidth * 0.35) {
+            const prevWidth = i > 0 ? measureText(lines[i - 1], letterSpacing) : Infinity;
+            const nextWidth = i < ii - 1 ? measureText(lines[i + 1], letterSpacing) : Infinity;
+            lines.splice(i, 1);
+            ii -= 1;
+            if (prevWidth < nextWidth) {
+              lines[i - 1] += ' ' + line;
+              i -= 1;
+            } else {
+              lines[i] = line + ' ' + lines[i];
+            }
           }
         }
       }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -6,7 +6,7 @@ describe('util', function() {
   describe('wrapText()', function() {
 
     it('should not combine undefined when no next line exists', function() {
-      const text = 'Shor T';
+      const text = 'i i';
       const result = wrapText(text, 'normal 400 12px/1.2 sans-serif', 10, 0);
       should(result).equal(text);
     });


### PR DESCRIPTION
Very short text with space like the house number '2 A' will get 'undefined' appended because both `prevWidth` and `nextWidth` are `Infinity` and the lines array is empty at that point.