### PR TITLE
Ensure text wrap array length > 1

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -147,20 +147,18 @@ export function wrapText(text, font, em, letterSpacing) {
         lines.push(line);
       }
       // Pass 2 - add lines with a width of less than 30% of maxWidth to the previous or next line
-      if (lines.length > 1) {
-        for (let i = 0, ii = lines.length; i < ii; ++i) {
-          const line = lines[i];
-          if (measureText(line, letterSpacing) < maxWidth * 0.35) {
-            const prevWidth = i > 0 ? measureText(lines[i - 1], letterSpacing) : Infinity;
-            const nextWidth = i < ii - 1 ? measureText(lines[i + 1], letterSpacing) : Infinity;
-            lines.splice(i, 1);
-            ii -= 1;
-            if (prevWidth < nextWidth) {
-              lines[i - 1] += ' ' + line;
-              i -= 1;
-            } else {
-              lines[i] = line + ' ' + lines[i];
-            }
+      for (let i = 0, ii = lines.length; i < ii && ii > 1; ++i) {
+        const line = lines[i];
+        if (measureText(line, letterSpacing) < maxWidth * 0.35) {
+          const prevWidth = i > 0 ? measureText(lines[i - 1], letterSpacing) : Infinity;
+          const nextWidth = i < ii - 1 ? measureText(lines[i + 1], letterSpacing) : Infinity;
+          lines.splice(i, 1);
+          ii -= 1;
+          if (prevWidth < nextWidth) {
+            lines[i - 1] += ' ' + line;
+            i -= 1;
+          } else {
+            lines[i] = line + ' ' + lines[i];
           }
         }
       }


### PR DESCRIPTION
This PR addresses @mikeydunnx concerns in https://github.com/openlayers/ol-mapbox-style/pull/283
Practically undefined should not be appended anymore but better to be explicit about it.