### PR TITLE
Ensure there is a / at join in tile urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -310,7 +310,7 @@ function setupVectorLayer(glSource, accessToken, url) {
         for (let i = 0, ii = tiles.length; i < ii; ++i) {
           const tile = tiles[i];
           if (tile.indexOf('http') != 0) {
-            tiles[i] = glSource.url + tile;
+            tiles[i] = glSource.url.replace(/\/?$/, '/') + tile.replace(/^\//, '');
           }
         }
       }


### PR DESCRIPTION
This fixes incorrect tile urls generated by olms for the Esri OSM style https://www.arcgis.com/sharing/rest/content/items/3e1a00aeae81496587988075fe529f71/resources/styles/root.json
where neither the tile json path ends with / nor the tiles relative url starts with /