### PR TITLE
Know which layer a feature belongs to

### DIFF
--- a/test/stylefunction.test.js
+++ b/test/stylefunction.test.js
@@ -1,6 +1,6 @@
 import should from 'should';
 import deepFreeze from 'deep-freeze';
-import applyStyleFunction from '../src/stylefunction';
+import applyStyleFunction, {recordStyleLayer} from '../src/stylefunction';
 import olms from '../src/index';
 import states from './fixtures/states.json';
 import Feature from 'ol/Feature';
@@ -14,6 +14,10 @@ describe('stylefunction', function() {
     beforeEach(function() {
       feature = new Feature(new Polygon([[[-1, -1], [-1, 1], [1, 1], [1, -1], [-1, -1]]]));
       layer = new VectorLayer();
+    });
+
+    afterEach(function() {
+      recordStyleLayer(false);
     });
 
     it('does not modify the input style object', function() {
@@ -61,6 +65,17 @@ describe('stylefunction', function() {
     it('should handle layer visibility', function() {
       const style = applyStyleFunction(layer, states, ['state_names']);
       should(style(feature, 1)).be.undefined();
+    });
+
+    it('records the style layer the feature belongs to', function() {
+      const style = applyStyleFunction(layer, states, ['population_lt_2m', 'population_gt_4m']);
+      recordStyleLayer(true);
+      feature.set('PERSONS', 5000000);
+      style(feature, 1);
+      should(feature.get('mapbox-layer').id).equal('population_gt_4m');
+      feature.set('PERSONS', 1000000);
+      style(feature, 1);
+      should(feature.get('mapbox-layer').id).equal('population_lt_2m');
     });
   });
 


### PR DESCRIPTION
Fixes #311.

This pull request adds a new function, `recordStyleLayer()`. When called with `true`, features evaluated by ol-mapbox-style's style function will receive a new property, `mapbox-layer`, with the topmost layer that the feature belongs to.

This is useful when using hit detection, to know which filter matched or which style was applied.

### Usage

#### Activate
```js
import { recordStyleLayer } from 'ol-mapbox-style/dist/stylefunction';

recordStyleLayer(true);
```

#### Hit detection
```js
const features = map.getFeaturesAtPixel(event.pixel);
if (features.length) {
  const mapboxLayer = feature.get('mapbox-layer');
  console.log(mapboxLayer.id);
}

