### PR TITLE
Support relative urls for TileJSON tiles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -485,7 +485,9 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken = '') {
             url = host + url;
           }
         }
-
+        if (glSource.tiles) {
+          glSource.tiles = glSource.tiles.map(url => withPath(url, path));
+        }
 
         if (glSource.type == 'vector') {
           layer = setupVectorLayer(glSource, accessToken, url);


### PR DESCRIPTION
To be consistent with the `url` for `geojson` and `vector` layers, the `tiles` property for `raster` layers now also supports relative paths.