### PR TITLE
fix: mapbox-gl-style-spec imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import View from 'ol/View.js';
 import applyStyleFunction, {getValue} from './stylefunction.js';
 import googleFonts from 'webfont-matcher/lib/fonts/google.js';
 import mb2css from 'mapbox-to-css-font';
-import {Color} from '@mapbox/mapbox-gl-style-spec/dist/index.es.js';
+import {Color} from '@mapbox/mapbox-gl-style-spec';
 import {assign, defaultResolutions} from './util.js';
 import {createXYZ} from 'ol/tilegrid.js';
 import {fromLonLat} from 'ol/proj.js';

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -20,7 +20,7 @@ import {
   expression,
   function as fn,
   latest as spec,
-} from '@mapbox/mapbox-gl-style-spec/dist/index.es.js';
+} from '@mapbox/mapbox-gl-style-spec';
 import {
   applyLetterSpacing,
   createCanvas,

--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -2,10 +2,7 @@
 import Feature from 'ol/Feature.js';
 import Point from 'ol/geom/Point.js';
 import should from 'should';
-import {
-  Color,
-  latest as spec,
-} from '@mapbox/mapbox-gl-style-spec';
+import {Color, latest as spec} from '@mapbox/mapbox-gl-style-spec';
 
 import {
   _colorWithOpacity as colorWithOpacity,

--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -5,7 +5,7 @@ import should from 'should';
 import {
   Color,
   latest as spec,
-} from '@mapbox/mapbox-gl-style-spec/dist/index.es.js';
+} from '@mapbox/mapbox-gl-style-spec';
 
 import {
   _colorWithOpacity as colorWithOpacity,

--- a/tsconfig-typecheck.json
+++ b/tsconfig-typecheck.json
@@ -9,7 +9,8 @@
     "baseUrl": "./",
     "paths": {
       "ol": ["node_modules/ol/src"],
-      "ol/*": ["node_modules/ol/src/*"]
+      "ol/*": ["node_modules/ol/src/*"],
+      "@mapbox/mapbox-gl-style-spec": ["node_modules/@mapbox/mapbox-gl-style-spec/dist/index.es.js"]
     },
     "lib": [
       "es2015",


### PR DESCRIPTION
## Why?

Importing the `es.js` files directly breaks non es builds.

## Fix

Import by library name. That way it takes the appropriate module type.