### PR TITLE
Include uid in functionCache index

### DIFF
--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -121,35 +121,56 @@ describe('utility functions currently in stylefunction.js', function () {
       'type': 'line',
     };
 
+    const uid = '1';
+
     it('should get correct default property', function () {
       const d = spec['layout_line']['line-cap']['default'];
 
-      should.equal(getValue(glLayer2, 'layout', 'line-cap', zoom, feature), d);
-      should(functionCache).have.key(glLayer2.id);
+      should.equal(
+        getValue(glLayer2, 'layout', 'line-cap', zoom, feature, uid),
+        d
+      );
+      should(functionCache).have.key(uid);
+      should(functionCache[uid]).have.key(glLayer2.id);
     });
 
     it('should get simple layout property', function () {
       should.equal(
-        getValue(glLayer, 'layout', 'visibility', zoom, feature),
+        getValue(glLayer, 'layout', 'visibility', zoom, feature, uid),
         'visible'
       );
-      should(functionCache).have.key(glLayer.id);
+      should(functionCache).have.key(uid);
+      should(functionCache[uid]).have.key(glLayer.id);
     });
 
     it('should get simple paint property', function () {
       should.equal(
-        getValue(glLayer, 'paint', 'fill-opacity', zoom, feature),
+        getValue(glLayer, 'paint', 'fill-opacity', zoom, feature, uid),
         0.7
       );
     });
 
     it('should get color paint property', function () {
-      const result = getValue(glLayer, 'paint', 'fill-color', zoom, feature);
+      const result = getValue(
+        glLayer,
+        'paint',
+        'fill-color',
+        zoom,
+        feature,
+        uid
+      );
       should(result).be.instanceof(Color);
     });
 
     it('should get complex paint property', function () {
-      const result = getValue(glLayer2, 'paint', 'line-gap-width', 20, feature);
+      const result = getValue(
+        glLayer2,
+        'paint',
+        'line-gap-width',
+        20,
+        feature,
+        uid
+      );
       should(result).equal(6);
     });
   });

--- a/test/stylefunction.test.js
+++ b/test/stylefunction.test.js
@@ -327,4 +327,78 @@ describe('stylefunction', function () {
         });
     });
   });
+
+  describe('Multiple related styles', function () {
+    let style;
+    beforeEach(function () {
+      style = {
+        version: '8',
+        name: 'test',
+        sources: {
+          'geojson': {
+            type: 'geojson',
+            data: {
+              type: 'FeatureCollection',
+              features: [
+                {
+                  type: 'Feature',
+                  geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                      [
+                        [-1, -1],
+                        [-1, 1],
+                        [1, 1],
+                        [1, -1],
+                        [-1, -1],
+                      ],
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+        layers: [
+          {
+            id: 'test',
+            type: 'fill',
+            source: 'geojson',
+            paint: {
+              'fill-color': '#A6CEE3',
+            },
+          },
+        ],
+      };
+    });
+
+    it('returns distinct values for same layer id', function (done) {
+      const style1 = JSON.parse(JSON.stringify(style));
+      const style2 = JSON.parse(JSON.stringify(style));
+      style2.layers[0].paint['fill-color'] = '#B2DF8A';
+
+      Promise.all([
+        olms(document.createElement('div'), style1),
+        olms(document.createElement('div'), style2),
+      ])
+        .then(function (maps) {
+          const layer1 = maps[0].getLayers().item(0);
+          const layer2 = maps[1].getLayers().item(0);
+          const styleFunction1 = layer1.getStyle();
+          const feature1 = layer1.getSource().getFeatures()[0];
+          const styles1 = styleFunction1(feature1, 1);
+          const fill1 = styles1[0].getFill();
+          should(fill1.getColor()).eql('rgba(166,206,227,1)');
+          const styleFunction2 = layer2.getStyle();
+          const feature2 = layer2.getSource().getFeatures()[0];
+          const styles2 = styleFunction2(feature2, 1);
+          const fill2 = styles2[0].getFill();
+          should(fill2.getColor()).eql('rgba(178,223,138,1)');
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/12862

Use the OpenLayers layer `uid` (or, for the background, the map `uid`) as an additional cache key for the `functionCache` and pass this in all calls to `getValue()`.  This will allow an application to have multiple maps (or a layer switcher) where the two or more different Mapbox styles share a tile set and therefore the same set of Gl layer ids.

There is a backward compatibility fallback to replicate the existing behaviour if `getValue()` is called externally without a `uid`.  However, subsequent to https://github.com/openlayers/openlayers/pull/13025 for background to work correctly with multiple layers once this is merged ol/layer/MapboxVector `configureSource()` should also be updated to pass `getUid(this)` to `getValue()` https://codesandbox.io/s/mapbox-vector-layer-forked-oi3w7?file=/main.js