### PR TITLE
Cache scope

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -244,6 +244,7 @@ function setBackground(map, layer) {
   const background = {
     type: layer.type,
   };
+  const functionCache = {};
   function updateStyle() {
     const element = map.getTargetElement();
     if (!element) {
@@ -261,7 +262,8 @@ function setBackground(map, layer) {
         'paint',
         'background-color',
         zoom,
-        emptyObj
+        emptyObj,
+        functionCache
       );
       element.style.background = Color.parse(bg).toString();
     }
@@ -271,7 +273,8 @@ function setBackground(map, layer) {
         'paint',
         'background-opacity',
         zoom,
-        emptyObj
+        emptyObj,
+        functionCache
       );
     }
     if (layout.visibility == 'none') {
@@ -471,9 +474,16 @@ function setupGeoJSONLayer(glSource, path) {
   });
 }
 
-function updateRasterLayerProperties(glLayer, layer, view) {
+function updateRasterLayerProperties(glLayer, layer, view, functionCache) {
   const zoom = view.getZoom();
-  const opacity = getValue(glLayer, 'paint', 'raster-opacity', zoom, emptyObj);
+  const opacity = getValue(
+    glLayer,
+    'paint',
+    'raster-opacity',
+    zoom,
+    emptyObj,
+    functionCache
+  );
   layer.setOpacity(opacity);
 }
 
@@ -558,11 +568,18 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken = '') {
           layer.setVisible(
             glLayer.layout ? glLayer.layout.visibility !== 'none' : true
           );
+          const functionCache = {};
           view.on(
             'change:resolution',
-            updateRasterLayerProperties.bind(this, glLayer, layer, view)
+            updateRasterLayerProperties.bind(
+              this,
+              glLayer,
+              layer,
+              view,
+              functionCache
+            )
           );
-          updateRasterLayerProperties(glLayer, layer, view);
+          updateRasterLayerProperties(glLayer, layer, view, functionCache);
         } else if (glSource.type == 'geojson') {
           layer = setupGeoJSONLayer(glSource, path);
         }

--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -7,9 +7,7 @@ import {Color, latest as spec} from '@mapbox/mapbox-gl-style-spec';
 import {
   _colorWithOpacity as colorWithOpacity,
   _evaluateFilter as evaluateFilter,
-  _filterCache as filterCache,
   _fromTemplate as fromTemplate,
-  _functionCache as functionCache,
   _getValue as getValue,
 } from '../src/stylefunction.js';
 
@@ -31,6 +29,7 @@ describe('utility functions currently in stylefunction.js', function () {
   });
 
   describe('evaluateFilter()', function () {
+    const filterCache = {};
     const feature = new Feature({geometry: new Point([0, 0], 'XY')});
     const zoom = 11;
 
@@ -39,15 +38,17 @@ describe('utility functions currently in stylefunction.js', function () {
       const filter = '[ "all" ]';
 
       should(filterCache).not.have.key(glLayerId);
-      should(evaluateFilter(glLayerId, filter, feature, zoom)).be.true;
-      should(filterCache).have.key(glLayerId);
+      should(evaluateFilter(glLayerId, filter, feature, zoom, filterCache)).be
+        .true;
+      should(filterCache, filterCache).have.key(glLayerId);
     });
 
     it('should be false with LineString filter and Point geom', function () {
       const glLayerId = 'gl-layer-id-2';
       const filter = '[ "==", "$type", "LineString" ]';
 
-      should(evaluateFilter(glLayerId, filter, feature, zoom)).be.false;
+      should(evaluateFilter(glLayerId, filter, feature, zoom, filterCache)).be
+        .false;
       should(filterCache).have.key(glLayerId);
     });
 
@@ -55,7 +56,8 @@ describe('utility functions currently in stylefunction.js', function () {
       const glLayerId = 'gl-layer-id-2';
       const filter = '[ "==", "$type", "Point" ]';
 
-      should(evaluateFilter(glLayerId, filter, feature, zoom)).be.false;
+      should(evaluateFilter(glLayerId, filter, feature, zoom, filterCache)).be
+        .false;
       should(filterCache).have.key(glLayerId);
     });
   });
@@ -96,6 +98,7 @@ describe('utility functions currently in stylefunction.js', function () {
   describe('getValue()', function () {
     const zoom = 11;
     const feature = new Feature({geometry: new Point([0, 0], 'XY')});
+    const functionCache = {};
     const glLayer = {
       'id': 'landuse-residential',
       'layout': {
@@ -124,13 +127,16 @@ describe('utility functions currently in stylefunction.js', function () {
     it('should get correct default property', function () {
       const d = spec['layout_line']['line-cap']['default'];
 
-      should.equal(getValue(glLayer2, 'layout', 'line-cap', zoom, feature), d);
+      should.equal(
+        getValue(glLayer2, 'layout', 'line-cap', zoom, feature, functionCache),
+        d
+      );
       should(functionCache).have.key(glLayer2.id);
     });
 
     it('should get simple layout property', function () {
       should.equal(
-        getValue(glLayer, 'layout', 'visibility', zoom, feature),
+        getValue(glLayer, 'layout', 'visibility', zoom, feature, functionCache),
         'visible'
       );
       should(functionCache).have.key(glLayer.id);

--- a/test/stylefunction.test.js
+++ b/test/stylefunction.test.js
@@ -327,4 +327,78 @@ describe('stylefunction', function () {
         });
     });
   });
+
+  describe('Multiple related styles', function () {
+    let style;
+    beforeEach(function () {
+      style = {
+        version: '8',
+        name: 'test',
+        sources: {
+          'geojson': {
+            type: 'geojson',
+            data: {
+              type: 'FeatureCollection',
+              features: [
+                {
+                  type: 'Feature',
+                  geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                      [
+                        [-1, -1],
+                        [-1, 1],
+                        [1, 1],
+                        [1, -1],
+                        [-1, -1],
+                      ],
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+        layers: [
+          {
+            id: 'test',
+            type: 'fill',
+            source: 'geojson',
+            paint: {
+              'fill-color': '#A6CEE3',
+            },
+          },
+        ],
+      };
+    });
+
+    it('returns distinct values for same layer id', function (done) {
+      const style1 = JSON.parse(JSON.stringify(style));
+      const style2 = JSON.parse(JSON.stringify(style));
+      style2.layers[0].paint['fill-color'] = '#B2DF8A';
+
+      Promise.all([
+        olms(document.createElement('div'), style1),
+        olms(document.createElement('div'), style2),
+      ])
+        .then(function (maps) {
+          const layer1 = maps[0].getLayers().item(0);
+          const layer2 = maps[1].getLayers().item(0);
+          const styleFunction1 = layer1.getStyle();
+          const feature1 = layer1.getSource().getFeatures()[0];
+          const styles1 = styleFunction1(feature1, 1);
+          const fill1 = styles1[0].getFill();
+          should(fill1.getColor()).eql('rgba(166,206,227,1)');
+          const styleFunction2 = layer2.getStyle();
+          const feature2 = layer2.getSource().getFeatures()[0];
+          const styles2 = styleFunction2(feature2, 1);
+          const fill2 = styles2[0].getFill();
+          should(fill2.getColor()).eql('rgba(178,223,138,1)');
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
+  });
 });


### PR DESCRIPTION
This pull request changes the scope of `filterCache` and `functionCache` to the `styleFunction`. This means that each `styleFunction()` invocation now has its own cache, avoiding cached functions or filters leaking into other styles.

I added @mike-000's test (159002509ed566cf97df88ebee9cb0be6db864be) from #375 to make sure that this pull request fixes the problem.

Supersedes and closes #375.
Fixes #390.