### PR TITLE
New renderTransparent() configuration option

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,16 @@
   "parserOptions": {
     "ecmaVersion": 6,
     "sourceType": "module"
+  },
+  "settings": {
+    "import/resolver": {
+      "alias": {
+        "map": [
+          ["ol-mapbox-style", "./src"],
+          ["ol-mapbox-style/dist/stylefunction", "./src"]
+        ],
+        "extensions": [".js", ".json"]
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -70,22 +70,24 @@ Internet Explorer (version 11) and other old browsers (Android 4.x) are supporte
 
 *   [applyStyle](#applystyle)
     *   [Parameters](#parameters)
-*   [recordStyleLayer](#recordstylelayer)
+*   [renderTransparent](#rendertransparent)
     *   [Parameters](#parameters-1)
-*   [stylefunction](#stylefunction)
+*   [recordStyleLayer](#recordstylelayer)
     *   [Parameters](#parameters-2)
-*   [applyBackground](#applybackground)
+*   [stylefunction](#stylefunction)
     *   [Parameters](#parameters-3)
-*   [olms](#olms)
+*   [applyBackground](#applybackground)
     *   [Parameters](#parameters-4)
-*   [apply](#apply)
+*   [olms](#olms)
     *   [Parameters](#parameters-5)
-*   [getLayer](#getlayer)
+*   [apply](#apply)
     *   [Parameters](#parameters-6)
-*   [getLayers](#getlayers)
+*   [getLayer](#getlayer)
     *   [Parameters](#parameters-7)
-*   [getSource](#getsource)
+*   [getLayers](#getlayers)
     *   [Parameters](#parameters-8)
+*   [getSource](#getsource)
+    *   [Parameters](#parameters-9)
 
 ### applyStyle
 
@@ -122,6 +124,18 @@ Two additional properties will be set on the provided layer:
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Promise which will be resolved when the style can be used
 for rendering.
+
+### renderTransparent
+
+Configure whether features with a transparent style should be rendered. When
+set to `true`, it will be possible to hit detect content that is not visible,
+like transparent fills of polygons, using `ol/layer/Layer#getFeatures()` or
+`ol/Map#getFeaturesAtPixel()`
+
+#### Parameters
+
+*   `enabled` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Rendering of transparent elements is enabled.
+    Default is `false`.
 
 ### recordStyleLayer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "documentation": "^13.2.5",
         "eslint": "^8.2.0",
         "eslint-config-openlayers": "^16.0.1",
+        "eslint-import-resolver-alias": "^1.1.2",
         "html-webpack-plugin": "^5.5.0",
         "karma": "^6.3.4",
         "karma-chrome-launcher": "^3.1.0",
@@ -4198,6 +4199,18 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -18364,6 +18377,13 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "documentation": "^13.2.5",
     "eslint": "^8.2.0",
     "eslint-config-openlayers": "^16.0.1",
+    "eslint-import-resolver-alias": "^1.1.2",
     "html-webpack-plugin": "^5.5.0",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",

--- a/src/olms.js
+++ b/src/olms.js
@@ -1,7 +1,17 @@
 import olms, {apply, applyBackground, applyStyle} from './index.js';
-import stylefunction from './stylefunction.js';
+import stylefunction, {
+  recordStyleLayer,
+  renderTransparent,
+} from './stylefunction.js';
 import {assign} from './util.js';
 
-assign(olms, {apply, applyBackground, applyStyle, stylefunction});
+assign(olms, {
+  apply,
+  applyBackground,
+  applyStyle,
+  stylefunction,
+  recordStyleLayer,
+  renderTransparent,
+});
 
 export default olms;

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -155,6 +155,20 @@ function evaluateFilter(layerId, filter, feature, zoom, filterCache) {
   return filterCache[layerId](zoomObj, feature);
 }
 
+let renderTransparentEnabled = false;
+
+/**
+ * Configure whether features with a transparent style should be rendered. When
+ * set to `true`, it will be possible to hit detect content that is not visible,
+ * like transparent fills of polygons, using `ol/layer/Layer#getFeatures()` or
+ * `ol/Map#getFeaturesAtPixel()`
+ * @param {boolean} enabled Rendering of transparent elements is enabled.
+ * Default is `false`.
+ */
+export function renderTransparent(enabled) {
+  renderTransparentEnabled = enabled;
+}
+
 /**
  * @private
  * @param {?} color Color.
@@ -163,7 +177,7 @@ function evaluateFilter(layerId, filter, feature, zoom, filterCache) {
  */
 function colorWithOpacity(color, opacity) {
   if (color) {
-    if (color.a === 0 || opacity === 0) {
+    if (!renderTransparentEnabled && (color.a === 0 || opacity === 0)) {
       return undefined;
     }
     const a = color.a;
@@ -534,7 +548,7 @@ export default function (
               fill.setColor(color);
               stroke = style.getStroke();
               stroke.setColor(strokeColor);
-              stroke.setWidth(1);
+              stroke.setWidth(0.5);
               style.setZIndex(index);
             }
           }

--- a/test/stylefunction.test.js
+++ b/test/stylefunction.test.js
@@ -1,7 +1,10 @@
 import Feature from 'ol/Feature.js';
 import Polygon from 'ol/geom/Polygon.js';
 import VectorLayer from 'ol/layer/Vector.js';
-import applyStyleFunction, {recordStyleLayer} from '../src/stylefunction.js';
+import applyStyleFunction, {
+  recordStyleLayer,
+  renderTransparent,
+} from '../src/stylefunction.js';
 import deepFreeze from 'deep-freeze';
 import olms from '../src/index.js';
 import should from 'should';
@@ -27,6 +30,7 @@ describe('stylefunction', function () {
 
     afterEach(function () {
       recordStyleLayer(false);
+      renderTransparent(false);
     });
 
     it('does not modify the input style object', function () {
@@ -88,6 +92,37 @@ describe('stylefunction', function () {
       feature.set('PERSONS', 1000000);
       style(feature, 1);
       should(feature.get('mapbox-layer').id).equal('population_lt_2m');
+    });
+
+    it('does not render transparent content by default', function () {
+      const styleObject = JSON.parse(JSON.stringify(states));
+      styleObject.layers.push({
+        'id': 'transparent',
+        'type': 'fill',
+        'source': 'states',
+        'paint': {
+          'fill-color': 'rgba(0,0,0,0)',
+        },
+      });
+      const styleFn = applyStyleFunction(layer, styleObject, ['transparent']);
+      const style = styleFn(feature, 1);
+      should(style).be.undefined;
+    });
+
+    it('renders transparent content when `renderTransparent(true)` is set', function () {
+      const styleObject = JSON.parse(JSON.stringify(states));
+      styleObject.layers.push({
+        'id': 'transparent',
+        'type': 'fill',
+        'source': 'states',
+        'paint': {
+          'fill-color': 'rgba(0,0,0,0)',
+        },
+      });
+      renderTransparent(true);
+      const styleFn = applyStyleFunction(layer, styleObject, ['transparent']);
+      const style = styleFn(feature, 1);
+      should(style).be.an.Array();
     });
   });
 


### PR DESCRIPTION
This pull request adds an option to render transparent content, e.g. invisible polygon fills, for hit detection. Example: when you want to have parcels rendered only with their outline, but want the whole parcel to be clickable, configure your style with
```json
  "layers": [
    {
      "id": "parcel",
      "source": "parcels",
      "type": "fill",
      "paint": {
        "fill-color": "rgba(0, 0, 0, 0)"
      }
    }, {
      "id": "parcel-outline",
      "source": "parcels",
      "type": "line",
      "paint": {
        "line-color": "rgb(0, 0, 0)",
        "line-width": 0.5
      }
    }
  ]
```
In your application code, configure the new option:
```js
import { renderTransparent } from 'ol-mapbox-style/dist/stylefunction';
renderTransparent(true);
```

Fixes #108.