### PR TITLE
Fix rgba colors with zero opacity

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -182,17 +182,17 @@ function colorWithOpacity(color, opacity) {
     }
     const a = color.a;
     opacity = opacity === undefined ? 1 : opacity;
-    return (
-      'rgba(' +
-      Math.round((color.r * 255) / a) +
-      ',' +
-      Math.round((color.g * 255) / a) +
-      ',' +
-      Math.round((color.b * 255) / a) +
-      ',' +
-      a * opacity +
-      ')'
-    );
+    return a === 0
+      ? 'transparent'
+      : 'rgba(' +
+          Math.round((color.r * 255) / a) +
+          ',' +
+          Math.round((color.g * 255) / a) +
+          ',' +
+          Math.round((color.b * 255) / a) +
+          ',' +
+          a * opacity +
+          ')';
   }
   return color;
 }

--- a/test/stylefunction.test.js
+++ b/test/stylefunction.test.js
@@ -123,6 +123,24 @@ describe('stylefunction', function () {
       const styleFn = applyStyleFunction(layer, styleObject, ['transparent']);
       const style = styleFn(feature, 1);
       should(style).be.an.Array();
+      should(style[0].getFill().getColor()).eql('transparent');
+    });
+
+    it('renders the correct fill color with opacity', function () {
+      const styleObject = JSON.parse(JSON.stringify(states));
+      styleObject.layers.push({
+        'id': 'transparent',
+        'type': 'fill',
+        'source': 'states',
+        'paint': {
+          'fill-color': 'rgba(16,234,42,0.5)',
+        },
+      });
+      renderTransparent(true);
+      const styleFn = applyStyleFunction(layer, styleObject, ['transparent']);
+      const style = styleFn(feature, 1);
+      should(style).be.an.Array();
+      should(style[0].getFill().getColor()).eql('rgba(16,234,42,0.5)');
     });
   });
 


### PR DESCRIPTION
When `renderTransparent(true)` is set, the color calculation fails because of a division by zero. This pull request changes things so when the alpha of a color is `0`, the css color `transparent` will be applied, instead of calculating a rgba value, which would cause a division by zero.