### PR TITLE
Use view properties (ol@>6.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "mapbox-gl-styles": "^2.0.2",
         "mini-css-extract-plugin": "^2.4.4",
         "mocha": "^9.1.3",
-        "ol": "^6.7.0",
+        "ol": "^6.9.0",
         "puppeteer": "^13.0.0",
         "should": "^13.2.3",
         "sinon": "^12.0.1",
@@ -9988,9 +9988,9 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.1.tgz",
-      "integrity": "sha512-diGjCUlYjCA855vJjQjPzxXLn/skm0iQLD2/yDsXaKdNxFd35hNfRm5Li+Vxh/FxraCodxRvd8IplhrhvXoqbQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.8.1.tgz",
+      "integrity": "sha512-HD3FNFzFiBptEwiLIVna7H/WSpv/cN99xMmIErcvqv/r4XLwWS/8VKti8w6moVPV28Fg2QmitXvaG3okedMU7w==",
       "dev": true,
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
@@ -22641,9 +22641,9 @@
       }
     },
     "ol-mapbox-style": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.1.tgz",
-      "integrity": "sha512-diGjCUlYjCA855vJjQjPzxXLn/skm0iQLD2/yDsXaKdNxFd35hNfRm5Li+Vxh/FxraCodxRvd8IplhrhvXoqbQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.8.1.tgz",
+      "integrity": "sha512-HD3FNFzFiBptEwiLIVna7H/WSpv/cN99xMmIErcvqv/r4XLwWS/8VKti8w6moVPV28Fg2QmitXvaG3okedMU7w==",
       "dev": true,
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "mapbox-gl-styles": "^2.0.2",
     "mini-css-extract-plugin": "^2.4.4",
     "mocha": "^9.1.3",
-    "ol": "^6.7.0",
+    "ol": "^6.9.0",
     "puppeteer": "^13.0.0",
     "should": "^13.2.3",
     "sinon": "^12.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -515,9 +515,11 @@ function processStyle(glStyle, map, baseUrl, host, path, accessToken = '') {
       ? isEmpty(view.options_)
       : !view.isDef() && !view.getRotation() && !view.getResolutions()
   ) {
-    view = new View({
-      maxResolution: defaultResolutions[0],
-    });
+    view = new View(
+      assign(view.getProperties(), {
+        maxResolution: defaultResolutions[0],
+      })
+    );
     map.setView(view);
   }
 


### PR DESCRIPTION
With openlayers/openlayers#13120, the private `options_` property of `ol/View` was removed, which we used in a hack to detect whether a view had modified defaults. Now that can be better handled by using `Object.assign(view.getProperties()...`. It's save to continue using the hack for users of older `ol` versions.