### PR TITLE
Avoid applying background if layout visibility is none

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -293,8 +293,8 @@ function setBackground(mapOrLayer, layer) {
       if (element) {
         element.style.backgroundColor = '';
         element.style.opacity = '';
-        return undefined;
       }
+      return undefined;
     }
     return _colorWithOpacity(bg, opacity);
   }

--- a/test/fixtures/background-none.json
+++ b/test/fixtures/background-none.json
@@ -1,0 +1,23 @@
+{
+  "version": 8,
+  "name": "background",
+  "metadata": {
+    "mapbox:autocomposite": true,
+    "mapbox:type": "template"
+  },
+  "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+  "sources": {},
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#f8f4f0",
+        "background-opacity": 0.75
+      },
+      "layout": {
+        "visibility": "none"
+      }
+    }
+  ]
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ import VectorSource from 'ol/source/Vector.js';
 import VectorTileLayer from 'ol/layer/VectorTile.js';
 import VectorTileSource from 'ol/source/VectorTile.js';
 import View from 'ol/View.js';
+import backgroundNoneStyle from './fixtures/background-none.json';
 import backgroundStyle from './fixtures/background.json';
 import brightV9 from 'mapbox-gl-styles/styles/bright-v9.json';
 import olms, {
@@ -84,6 +85,30 @@ describe('ol-mapbox-style', function () {
       }
       applyBackground(layer, backgroundStyle);
       should(layer.getBackground()(1)).be.exactly('rgba(248,244,240,0.75)');
+    });
+    it('ignores background if layout: none (with map container)', function () {
+      const target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      const map = new Map({target: target});
+      applyBackground(map, backgroundNoneStyle);
+      should(target.style.backgroundColor).be.exactly('');
+      should(target.style.opacity).be.eql('');
+    });
+    it('ignores background if layout: none (with a layer)', function () {
+      const layer = new VectorTileLayer({
+        source: new VectorTileSource({}),
+      });
+      if (typeof layer.setBackground !== 'function') {
+        layer.setBackground = function (background) {
+          layer.background = background;
+        };
+        layer.getBackground = function () {
+          return layer.background;
+        };
+      }
+      applyBackground(layer, backgroundNoneStyle);
+      should(layer.getBackground()(1)).be.undefined();
     });
   });
 


### PR DESCRIPTION
In cases where a background layer has `"visibility": "none"` for the layout, the background color and opacity should not be applied.

It looks like the current code handles the case where a map (with a target element) is passed to `applyStyle` but not the case where a layer is passed.