### PR TITLE
Allow outline stroke for polygons without fill

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -517,41 +517,48 @@ export default function (
               ),
               opacity
             );
-            if (color) {
-              if (layer.type + '-outline-color' in paint) {
-                strokeColor = colorWithOpacity(
-                  getValue(
-                    layer,
-                    'paint',
-                    layer.type + '-outline-color',
-                    zoom,
-                    f,
-                    functionCache
-                  ),
-                  opacity
-                );
-              }
-              if (!strokeColor) {
-                strokeColor = color;
-              }
+            if (layer.type + '-outline-color' in paint) {
+              strokeColor = colorWithOpacity(
+                getValue(
+                  layer,
+                  'paint',
+                  layer.type + '-outline-color',
+                  zoom,
+                  f,
+                  functionCache
+                ),
+                opacity
+              );
+            }
+            if (!strokeColor) {
+              strokeColor = color;
+            }
+            if (color || strokeColor) {
               ++stylesLength;
               style = styles[stylesLength];
               if (
                 !style ||
-                !(style.getFill() && style.getStroke()) ||
+                (color && !style.getFill()) ||
+                (!color && style.getFill()) ||
+                (strokeColor && !style.getStroke()) ||
+                (!strokeColor && style.getStroke()) ||
                 style.getText()
               ) {
                 style = new Style({
-                  fill: new Fill(),
-                  stroke: new Stroke(),
+                  fill: color ? new Fill() : undefined,
+                  stroke: strokeColor ? new Stroke() : undefined,
                 });
                 styles[stylesLength] = style;
               }
-              fill = style.getFill();
-              fill.setColor(color);
-              stroke = style.getStroke();
-              stroke.setColor(strokeColor);
-              stroke.setWidth(0.5);
+              if (color) {
+                fill = style.getFill();
+                fill.setColor(color);
+              }
+              if (strokeColor) {
+                stroke = style.getStroke();
+                stroke.setColor(strokeColor);
+                stroke.setWidth(0.5);
+              }
               style.setZIndex(index);
             }
           }

--- a/test/stylefunction.test.js
+++ b/test/stylefunction.test.js
@@ -142,6 +142,25 @@ describe('stylefunction', function () {
       should(style).be.an.Array();
       should(style[0].getFill().getColor()).eql('rgba(16,234,42,0.5)');
     });
+
+    it('renders the outline when fill has zero opacity', function () {
+      const styleObject = JSON.parse(JSON.stringify(states));
+      styleObject.layers.push({
+        'id': 'transparent',
+        'type': 'fill',
+        'source': 'states',
+        'paint': {
+          'fill-color': 'rgba(16,234,42,0)',
+          'fill-outline-color': 'red',
+        },
+      });
+      renderTransparent(false);
+      const styleFn = applyStyleFunction(layer, styleObject, ['transparent']);
+      const style = styleFn(feature, 1);
+      should(style).be.an.Array();
+      should(style[0].getFill()).eql(null);
+      should(style[0].getStroke().getColor()).eql('rgba(255,0,0,1)');
+    });
   });
 
   describe('Points with labels', function () {


### PR DESCRIPTION
This pull request fixes the behavior when a fill-outline-color is set but no fill is rendered. In this case, the outline was previously not rendered. Now it is.