### PR TITLE
Use default for circle-radius

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -853,7 +853,7 @@ export default function (
           }
         }
 
-        if (type == 1 && 'circle-radius' in paint) {
+        if (type == 1 && layer.type === 'circle') {
           ++stylesLength;
           style = styles[stylesLength];
           if (
@@ -865,14 +865,17 @@ export default function (
             style = new Style();
             styles[stylesLength] = style;
           }
-          const circleRadius = getValue(
-            layer,
-            'paint',
-            'circle-radius',
-            zoom,
-            f,
-            functionCache
-          );
+          const circleRadius =
+            'circle-radius' in paint
+              ? getValue(
+                  layer,
+                  'paint',
+                  'circle-radius',
+                  zoom,
+                  f,
+                  functionCache
+                )
+              : 5;
           const circleStrokeColor = colorWithOpacity(
             getValue(
               layer,


### PR DESCRIPTION
This pull request makes `circle` styles work when no `circle-radius` is specified, by assuming the default of `5`.