### PR TITLE
Declutter also vector layers, allow text overflow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -483,6 +483,7 @@ function setupGeoJSONLayer(glSource, path) {
     });
   }
   return new VectorLayer({
+    declutter: true,
     source: new VectorSource({
       attributions: glSource.attribution,
       features: features,

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1071,6 +1071,7 @@ export default function (
             style.setText(
               text ||
                 new Text({
+                  overflow: true,
                   padding: [2, 2, 2, 2],
                 })
             );


### PR DESCRIPTION
Currently, vector and vector tile layers are treated differently: for the former, decluttering is off, for the latter, it is on. This pull request makes the behavior more consistent by adding decluttering also to vector layers. In addition, the `overflow: true` option is set for text styles, for better label placement on vector tile layers.