### PR TITLE
Add transformRequest support for tile URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 #### Properties
 
 *   `accessToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Access token for 'mapbox://' urls.
-*   `transformRequest` **function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): [Request](https://developer.mozilla.org/Add-ons/SDK/High-Level_APIs/request)?** Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
+*   `transformRequest` **function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), ResourceType): [Request](https://developer.mozilla.org/Add-ons/SDK/High-Level_APIs/request)?** Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
     the url, adding headers or setting credentials options. Called with the url and the resource
-    type as arguments, this function is supposed to return a `Request` object.
+    type as arguments, this function is supposed to return a `Request` object. For `Tile` resources,
+    only the `url` of the returned request will be respected.
 *   `styleUrl` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** URL of the Mapbox GL style. Required for styles that were provided
     as object, when they contain a relative sprite url.
 *   `accessTokenParam` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Access token param. For internal use.

--- a/examples/esri-transformrequest.js
+++ b/examples/esri-transformrequest.js
@@ -1,0 +1,18 @@
+import 'ol/ol.css';
+import olms from 'ol-mapbox-style';
+
+olms(
+  'map',
+  'https://www.arcgis.com/sharing/rest/content/items/2afe5b807fa74006be6363fd243ffb30/resources/styles/root.json',
+  {
+    transformRequest(url, type) {
+      if (type === 'Tile') {
+        url = url.replace(
+          'World_Basemap_v2/tile/',
+          'World_Basemap_v2/VectorTileServer/tile/'
+        );
+      }
+      return new Request(url);
+    },
+  }
+);

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,6 +21,7 @@
     <li><a href="wms.html">OSM with WMS overlay</a> &ndash; Map with two raster layers (OSM base map and WMS overlay)</li>
     <li><a href="tilejson.html">TileJSON</a> &ndash; Map with a raster layer from a TileJSON definition</li>
     <li><a href="tilejson-vectortile.html">TileJSON vector tiles</a> &ndash; Vector tile map with a source from a TileJSON definition</li>
+    <li><a href="esri-transformrequest.html">Esri vector tiles with bad tile URLs</a> &ndash; Esri vector tile map using the <code>transformRequest</code> option to fix tile urls.</li>
     <li><a href="openmaptiles-layer.html">OpenMapTiles Layer</a> (requires a <a href="https://cloud.maptiler.com/account/keys">Maptiler Cloud API token</a>) &ndash; Vector tile layer from OpenMapTiles's basic style</li>
     <li><a href="geojson-layer.html">GeoJSON Layer</a> &ndash; Vector layer from GeoJSON</li>
     <li><a href="stylefunction.html">Style function</a> &ndash; Low-level API for creating a style function from a Mapbox Style source</li>

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,19 +1,11 @@
 {
   "compilerOptions": {
     "checkJs": true,
-    "baseUrl": "./",
-    "paths": {
-      "ol": ["node_modules/ol/src"],
-      "ol/*": ["node_modules/ol/src/*"]
-    },
+    "resolveJsonModule": true,
     "lib": [
       "es2015",
       "dom",
       "webworker"
     ]
-  },
-  "include": [
-    "*.js",
-    "node_modules/ol/**/*.js"
-  ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@types/arcgis-rest-api": "^10.4.4",
         "@types/geojson": "^7946.0.7",
+        "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.1",
         "@types/offscreencanvas": "^2019.6.4",
         "@types/topojson-specification": "^1.0.1",
@@ -793,6 +794,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -15578,6 +15585,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz",
+      "integrity": "sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/arcgis-rest-api": "^10.4.4",
     "@types/geojson": "^7946.0.7",
+    "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.1",
     "@types/offscreencanvas": "^2019.6.4",
     "@types/topojson-specification": "^1.0.1",

--- a/test/applyStyle.test.js
+++ b/test/applyStyle.test.js
@@ -32,6 +32,51 @@ describe('applyStyle with source creation', function () {
       }
     });
   });
+  it('configures vector tile layer with source and style', function (done) {
+    const layer = new VectorTileLayer();
+    applyStyle(layer, '/fixtures/osm-liberty/style.json')
+      .then(function () {
+        try {
+          should(layer.getSource()).be.an.instanceOf(VectorTileSource);
+          should(layer.getSource().getUrls()[0]).equal(
+            'http://localhost:9876/fixtures/osm-liberty/tiles/v3/{z}/{x}/{y}.pbf'
+          );
+          should(layer.getStyle()).be.an.instanceOf(Function);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      })
+      .catch(function (e) {
+        done(e);
+      });
+  });
+  it('respects the transformRequest options', function (done) {
+    const layer = new VectorTileLayer();
+    applyStyle(layer, '/fixtures/osm-liberty/style.json', 'openmaptiles', {
+      transformRequest(url, type) {
+        if (type === 'Tile') {
+          url += '?foo=bar';
+        }
+        return new Request(url);
+      },
+    })
+      .then(function () {
+        try {
+          should(layer.getSource()).be.an.instanceOf(VectorTileSource);
+          should(layer.getSource().getUrls()[0]).equal(
+            'http://localhost:9876/fixtures/osm-liberty/tiles/v3/{z}/{x}/{y}.pbf?foo=bar'
+          );
+          should(layer.getStyle()).be.an.instanceOf(Function);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      })
+      .catch(function (e) {
+        done(e);
+      });
+  });
 });
 
 describe('applyStyle style argument validation', function () {

--- a/test/fixtures/osm-liberty/tiles.json
+++ b/test/fixtures/osm-liberty/tiles.json
@@ -865,7 +865,7 @@
       20037471.205137063
   ],
   "tiles": [
-      "https://api.maptiler.com/tiles/v3/{z}/{x}/{y}.pbf?key=lirfd6Fegsjkvs0lshxe"
+      "./tiles/v3/{z}/{x}/{y}.pbf"
   ],
   "logo": "https://api.maptiler.com/resources/logo.svg"
 }


### PR DESCRIPTION
This pull request adds `Tile` as 4th resource type, so now also tile urls can be modified.

A new example, `esri-transformrequest.js`, shows how to make use of this.