### PR TITLE
Mapbox style spec direct import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,11 +11,16 @@
     "import/resolver": {
       "alias": {
         "map": [
+          ["@mapbox/mapbox-gl-style-spec", "./node_modules/@mapbox/mapbox-gl-style-spec"],
           ["ol-mapbox-style", "./src"],
           ["ol-mapbox-style/dist/stylefunction", "./src"]
         ],
         "extensions": [".js", ".json"]
       }
     }
+  },
+  "rules": {
+    "import/default": "off",
+    "import/named": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use the library in an application with an npm based dev environment, install 
 
     npm install ol-mapbox-style
 
-When installed this way, just import the ol-mapbox-style module, like in the usage example below. To use a standalone build of ol-mapbox-style, just include 'dist/olms.js' on your HTML page, and access the global `olms` object. Note that the standalone build depends on the legacy build of OpenLayers.
+When installed this way, just import the ol-mapbox-style module, like in the usage example below. To use a standalone build of ol-mapbox-style, just include 'dist/olms.js' on your HTML page, and access the exported functions from the global `olms` object (e.g. `olms.default()`, `olms.applyBackground()`). Note that the standalone build depends on the legacy build of OpenLayers.
 
 **ol-mapbox-style requires [OpenLayers](https://npmjs.com/package/ol) version >= 6.13.0 < 7**.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.1.1",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@openlayers/mapbox-gl-style-spec": "^13.24.0-alpha.9",
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1",
         "webfont-matcher": "^1.1.0"
       },
@@ -32,6 +32,7 @@
         "eslint-config-openlayers": "^16.0.1",
         "eslint-import-resolver-alias": "^1.1.2",
         "html-webpack-plugin": "^5.5.0",
+        "json-strip-loader": "^1.0.5",
         "karma": "^6.3.4",
         "karma-chrome-launcher": "^3.1.0",
         "karma-coverage-istanbul-reporter": "^3.0.3",
@@ -41,8 +42,10 @@
         "mapbox-gl-styles": "^2.0.2",
         "mini-css-extract-plugin": "^2.4.4",
         "mocha": "^9.1.3",
+        "nanoassert": "^2.0.0",
         "ol": "^6.14.1",
         "puppeteer": "^13.0.0",
+        "remove-flow-types-loader": "^1.1.0",
         "should": "^13.2.3",
         "sinon": "^13.0.0",
         "style-loader": "^3.3.1",
@@ -506,7 +509,6 @@
       "version": "13.23.1",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.23.1.tgz",
       "integrity": "sha512-C6wh8A/5EdsgzhL6y6yl464VCQNIxK0yjrpnvCvchcFe3sNK2RbBw/J9u3m+p8Y6S6MsGuSMt3AkGAXOKMYweQ==",
-      "dev": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -567,27 +569,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@openlayers/mapbox-gl-style-spec": {
-      "version": "13.24.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@openlayers/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.24.0-alpha.9.tgz",
-      "integrity": "sha512-qEks94sCvfrJWTTd/dzxEA/taA4HASOg8jzc9jSllTNFAc2Qdc3L8NE8Mf7TfbB0CiEODspunwa6PMGA/3Rspw==",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      },
-      "bin": {
-        "gl-style-composite": "bin/gl-style-composite.js",
-        "gl-style-format": "bin/gl-style-format.js",
-        "gl-style-migrate": "bin/gl-style-migrate.js",
-        "gl-style-validate": "bin/gl-style-validate.js"
       }
     },
     "node_modules/@petamoriken/float16": {
@@ -773,6 +754,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.181",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
+      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==",
       "dev": true
     },
     "node_modules/@types/mdast": {
@@ -1628,6 +1615,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true,
+      "bin": {
+        "babylon": "bin/babylon.js"
       }
     },
     "node_modules/bail": {
@@ -5455,6 +5451,20 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "node_modules/flow-remove-types": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-1.2.3.tgz",
+      "integrity": "sha512-ypq/U3V+t9atYiOuSJd40tekCra03EHKoRsiK/wXGrsZimuum0kdwVY7Yv0HTaoXgHW1WiayomYd+Q3kkvPl9Q==",
+      "dev": true,
+      "dependencies": {
+        "babylon": "^6.15.0",
+        "vlq": "^0.2.1"
+      },
+      "bin": {
+        "flow-node": "flow-node",
+        "flow-remove-types": "flow-remove-types"
+      }
+    },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -7609,6 +7619,18 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "node_modules/json-strip-loader": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/json-strip-loader/-/json-strip-loader-1.0.5.tgz",
+      "integrity": "sha512-ErPhYdI8RsCfLvciRVtOrC4oPSo+mIq2XD3RvE0MMTfYZXD4NmLF1MSMKeohiqdp0m921+udnpRma89GmqQgPw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "^4.14.117",
+        "loader-utils": "^1.0.2",
+        "lodash": "^4.17.11",
+        "strip-keys": "^1.0.4"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -9597,6 +9619,12 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "dev": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
@@ -11400,6 +11428,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remove-flow-types-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-flow-types-loader/-/remove-flow-types-loader-1.1.0.tgz",
+      "integrity": "sha512-9diL4hIexIzoql2q2G9DrYjvM3hId+56QrkJJwnRmynXZ102pHAPyMfgyoPo3bgUeDIHR5lJLVWTX3GAbvAuoQ==",
+      "dev": true,
+      "dependencies": {
+        "flow-remove-types": "^1.0.0",
+        "loader-utils": "^1.1.0"
+      }
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -13062,6 +13100,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-keys": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strip-keys/-/strip-keys-1.0.5.tgz",
+      "integrity": "sha512-J5e93J9slFXgfSO78ssXXlE+tshuBzVov8hzeJrRcPArXNtH8U3U+S9D2O6P/aZ3UFlgoXhpWJREctPG7DhZMw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "^4.14.53",
+        "lodash": "^4.17.4"
+      }
+    },
     "node_modules/style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
@@ -14141,6 +14189,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
     },
     "node_modules/void-elements": {
       "version": "2.0.1",
@@ -15332,7 +15386,6 @@
       "version": "13.23.1",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.23.1.tgz",
       "integrity": "sha512-C6wh8A/5EdsgzhL6y6yl464VCQNIxK0yjrpnvCvchcFe3sNK2RbBw/J9u3m+p8Y6S6MsGuSMt3AkGAXOKMYweQ==",
-      "dev": true,
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -15378,21 +15431,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
-      }
-    },
-    "@openlayers/mapbox-gl-style-spec": {
-      "version": "13.24.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@openlayers/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.24.0-alpha.9.tgz",
-      "integrity": "sha512-qEks94sCvfrJWTTd/dzxEA/taA4HASOg8jzc9jSllTNFAc2Qdc3L8NE8Mf7TfbB0CiEODspunwa6PMGA/3Rspw==",
-      "requires": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
       }
     },
     "@petamoriken/float16": {
@@ -15578,6 +15616,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.181",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
+      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==",
       "dev": true
     },
     "@types/mdast": {
@@ -16298,6 +16342,12 @@
       "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
       "dev": true,
       "requires": {}
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "bail": {
       "version": "1.0.5",
@@ -19312,6 +19362,16 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "flow-remove-types": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-1.2.3.tgz",
+      "integrity": "sha512-ypq/U3V+t9atYiOuSJd40tekCra03EHKoRsiK/wXGrsZimuum0kdwVY7Yv0HTaoXgHW1WiayomYd+Q3kkvPl9Q==",
+      "dev": true,
+      "requires": {
+        "babylon": "^6.15.0",
+        "vlq": "^0.2.1"
+      }
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -20886,6 +20946,18 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json-strip-loader": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/json-strip-loader/-/json-strip-loader-1.0.5.tgz",
+      "integrity": "sha512-ErPhYdI8RsCfLvciRVtOrC4oPSo+mIq2XD3RvE0MMTfYZXD4NmLF1MSMKeohiqdp0m921+udnpRma89GmqQgPw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "^4.14.117",
+        "loader-utils": "^1.0.2",
+        "lodash": "^4.17.11",
+        "strip-keys": "^1.0.4"
+      }
+    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -22414,6 +22486,12 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "dev": true
+    },
     "nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
@@ -23778,6 +23856,16 @@
         "through2": "^2.0.3"
       }
     },
+    "remove-flow-types-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-flow-types-loader/-/remove-flow-types-loader-1.1.0.tgz",
+      "integrity": "sha512-9diL4hIexIzoql2q2G9DrYjvM3hId+56QrkJJwnRmynXZ102pHAPyMfgyoPo3bgUeDIHR5lJLVWTX3GAbvAuoQ==",
+      "dev": true,
+      "requires": {
+        "flow-remove-types": "^1.0.0",
+        "loader-utils": "^1.1.0"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -25139,6 +25227,16 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "strip-keys": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strip-keys/-/strip-keys-1.0.5.tgz",
+      "integrity": "sha512-J5e93J9slFXgfSO78ssXXlE+tshuBzVov8hzeJrRcPArXNtH8U3U+S9D2O6P/aZ3UFlgoXhpWJREctPG7DhZMw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "^4.14.53",
+        "lodash": "^4.17.4"
+      }
+    },
     "style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
@@ -25966,6 +26064,12 @@
           }
         }
       }
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
     },
     "void-elements": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ol-mapbox-style",
-  "version": "7.1.1",
+  "version": "8.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ol-mapbox-style",
-      "version": "7.1.1",
+      "version": "8.0.0-beta.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "npm run karma -- --single-run --log-level error"
   },
   "dependencies": {
-    "@openlayers/mapbox-gl-style-spec": "^13.24.0-alpha.9",
+    "@mapbox/mapbox-gl-style-spec": "^13.23.1",
     "mapbox-to-css-font": "^2.4.1",
     "webfont-matcher": "^1.1.0"
   },
@@ -53,6 +53,7 @@
     "eslint-config-openlayers": "^16.0.1",
     "eslint-import-resolver-alias": "^1.1.2",
     "html-webpack-plugin": "^5.5.0",
+    "json-strip-loader": "^1.0.5",
     "karma": "^6.3.4",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^3.0.3",
@@ -62,8 +63,10 @@
     "mapbox-gl-styles": "^2.0.2",
     "mini-css-extract-plugin": "^2.4.4",
     "mocha": "^9.1.3",
+    "nanoassert": "^2.0.0",
     "ol": "^6.14.1",
     "puppeteer": "^13.0.0",
+    "remove-flow-types-loader": "^1.1.0",
     "should": "^13.2.3",
     "sinon": "^13.0.0",
     "style-loader": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "name": "ol-mapbox-style",
-  "version": "7.1.1",
+  "version": "8.0.0-beta.0",
   "description": "Create OpenLayers maps from Mapbox Style objects",
   "main": "dist/olms.js",
-  "module": "dist/index.js",
+  "module": "dist/olms.es.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "module": "./dist/olms.es.js",
+      "require": "./dist/olms.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/openlayers/ol-mapbox-style.git"

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ Copyright 2016-present ol-mapbox-style contributors
 License: https://raw.githubusercontent.com/openlayers/ol-mapbox-style/master/LICENSE
 */
 
-import Color from '@openlayers/mapbox-gl-style-spec/Color';
+import Color from '@mapbox/mapbox-gl-style-spec/util/color.js';
 import GeoJSON from 'ol/format/GeoJSON.js';
 import MVT from 'ol/format/MVT.js';
 import Map from 'ol/Map.js';

--- a/src/olms.js
+++ b/src/olms.js
@@ -9,9 +9,9 @@ import stylefunction, {
   recordStyleLayer,
   renderTransparent,
 } from './stylefunction.js';
-import {assign} from 'ol/obj.js';
 
-assign(olms, {
+export {
+  olms as default,
   apply,
   applyBackground,
   applyStyle,
@@ -20,6 +20,4 @@ assign(olms, {
   stylefunction,
   recordStyleLayer,
   renderTransparent,
-});
-
-export default olms;
+};

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -12,16 +12,13 @@ import Stroke from 'ol/style/Stroke.js';
 import Style from 'ol/style/Style.js';
 import Text from 'ol/style/Text.js';
 
-import Color from '@openlayers/mapbox-gl-style-spec/Color';
-import createFilter from '@openlayers/mapbox-gl-style-spec/featureFilter';
-import derefLayers from '@openlayers/mapbox-gl-style-spec/derefLayers';
+import Color from '@mapbox/mapbox-gl-style-spec/util/color.js';
+import convertFunction from '@mapbox/mapbox-gl-style-spec/function/convert.js';
+import createFilter from '@mapbox/mapbox-gl-style-spec/feature_filter/index.js';
+import derefLayers from '@mapbox/mapbox-gl-style-spec/deref.js';
 import mb2css from 'mapbox-to-css-font';
-import spec from '@openlayers/mapbox-gl-style-spec/latest';
+import spec from '@mapbox/mapbox-gl-style-spec/reference/v8.json';
 import {applyLetterSpacing, wrapText} from './text.js';
-import {
-  convertFunction,
-  isFunction,
-} from '@openlayers/mapbox-gl-style-spec/function';
 import {
   createCanvas,
   defaultResolutions,
@@ -31,7 +28,8 @@ import {
 import {
   createPropertyExpression,
   isExpression,
-} from '@openlayers/mapbox-gl-style-spec/expression';
+} from '@mapbox/mapbox-gl-style-spec/expression/index.js';
+import {isFunction} from '@mapbox/mapbox-gl-style-spec/function/index.js';
 
 /**
  * @typedef {import("ol/layer/Vector").default} VectorLayer
@@ -175,7 +173,7 @@ export function renderTransparent(enabled) {
 /**
  * @private
  * @param {?} color Color.
- * @param {number} opacity Opacity.
+ * @param {number} [opacity] Opacity.
  * @return {string} Color.
  */
 function colorWithOpacity(color, opacity) {

--- a/test/karma.conf.cjs
+++ b/test/karma.conf.cjs
@@ -1,3 +1,4 @@
+const {join} = require('path');
 const path = require('path');
 
 module.exports = function (karma) {
@@ -52,7 +53,24 @@ module.exports = function (karma) {
             exclude: /node_modules|\.test\.js$/,
             use: 'coverage-istanbul-loader',
           },
+          {
+            test: /\.js$/,
+            enforce: 'pre',
+            use: ['remove-flow-types-loader'],
+            include: join(
+              __dirname,
+              '..',
+              'node_modules',
+              '@mapbox',
+              'mapbox-gl-style-spec'
+            ),
+          },
         ],
+      },
+      resolve: {
+        fallback: {
+          'assert': path.join(__dirname, '..', 'node_modules', 'nanoassert'),
+        },
       },
     },
     webpackMiddleware: {

--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -1,9 +1,9 @@
 /*eslint no-console: "off"*/
-import Color from '@openlayers/mapbox-gl-style-spec/Color';
+import Color from '@mapbox/mapbox-gl-style-spec/util/color.js';
 import Feature from 'ol/Feature.js';
 import Point from 'ol/geom/Point.js';
 import should from 'should';
-import spec from '@openlayers/mapbox-gl-style-spec/latest';
+import spec from '@mapbox/mapbox-gl-style-spec/reference/v8.json';
 
 import {
   _colorWithOpacity as colorWithOpacity,
@@ -41,7 +41,7 @@ describe('utility functions currently in stylefunction.js', function () {
       should(filterCache).not.have.key(glLayerId);
       should(evaluateFilter(glLayerId, filter, feature, zoom, filterCache)).be
         .true;
-      should(filterCache, filterCache).have.key(glLayerId);
+      should(filterCache).have.key(glLayerId);
     });
 
     it('should be false with LineString filter and Point geom', function () {

--- a/tsconfig-typecheck.json
+++ b/tsconfig-typecheck.json
@@ -7,6 +7,8 @@
     "moduleResolution": "node",
     "module": "ESNext",
     "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
     "baseUrl": "./",
     "lib": [
       "es2015",

--- a/webpack.config.examples.cjs
+++ b/webpack.config.examples.cjs
@@ -3,6 +3,7 @@ const fs = require('fs');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const {join} = require('path');
 
 /** Get the list of examples from the examples directory.
  *
@@ -96,6 +97,9 @@ module.exports = (env, argv) => {
         'ol-mapbox-style/dist': path.join(__dirname, 'src'),
         'ol-mapbox-style': path.join(__dirname, 'src'),
       },
+      fallback: {
+        'assert': path.join(__dirname, 'node_modules', 'nanoassert'),
+      },
     },
     devtool: 'source-map',
     module: {
@@ -109,10 +113,29 @@ module.exports = (env, argv) => {
         },
         {
           test: /\.js$/,
-          include: [
+          enforce: 'pre',
+          use: ['remove-flow-types-loader'],
+          include: join(
             __dirname,
-            /node_modules\/(?!(@mapbox\/mapbox-gl-style-spec)\/)/,
-          ],
+            'node_modules',
+            '@mapbox',
+            'mapbox-gl-style-spec'
+          ),
+        },
+        {
+          type: 'javascript/auto',
+          test: /\.json$/,
+          include: join(
+            __dirname,
+            'node_modules',
+            '@mapbox',
+            'mapbox-gl-style-spec',
+            'reference'
+          ),
+          use: ['json-strip-loader?keys[]=doc,keys[]=example'],
+        },
+        {
+          test: /\.js$/,
           use: {
             loader: 'buble-loader',
             options: {

--- a/webpack.config.olms.cjs
+++ b/webpack.config.olms.cjs
@@ -35,12 +35,17 @@ function createExternals() {
       commonjs: key,
       commonjs2: key,
       amd: key,
+      module: key,
     };
   }
   return createdExternals;
 }
 
-module.exports = {
+/**
+ * @param {'js' | 'es.js'} type Type.
+ * @return {Object} Webpack config.
+ */
+const createConfig = (type) => ({
   entry: './src/olms.js',
   devtool: 'source-map',
   mode: 'production',
@@ -83,10 +88,11 @@ module.exports = {
   },
   output: {
     path: path.resolve('./dist'), // Path of output file
-    filename: 'olms.js',
-    library: 'olms',
-    libraryTarget: 'umd',
-    libraryExport: 'default',
+    filename: `olms.${type}`,
+    library: {
+      name: type === 'js' ? 'olms' : undefined,
+      type: type === 'js' ? 'umd' : 'module',
+    },
   },
   resolve: {
     fallback: {
@@ -94,4 +100,9 @@ module.exports = {
     },
   },
   externals: createExternals(),
-};
+  experiments: {
+    outputModule: type === 'es.js',
+  },
+});
+
+module.exports = [createConfig('js'), createConfig('es.js')];

--- a/webpack.config.olms.cjs
+++ b/webpack.config.olms.cjs
@@ -1,3 +1,4 @@
+const {join} = require('path');
 const path = require('path');
 
 const externals = {
@@ -47,6 +48,29 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
+        enforce: 'pre',
+        use: ['remove-flow-types-loader'],
+        include: join(
+          __dirname,
+          'node_modules',
+          '@mapbox',
+          'mapbox-gl-style-spec'
+        ),
+      },
+      {
+        type: 'javascript/auto',
+        test: /\.json$/,
+        include: join(
+          __dirname,
+          'node_modules',
+          '@mapbox',
+          'mapbox-gl-style-spec',
+          'reference'
+        ),
+        use: ['json-strip-loader?keys[]=doc,keys[]=example'],
+      },
+      {
+        test: /\.js$/,
         include: [__dirname],
         use: {
           loader: 'buble-loader',
@@ -63,6 +87,11 @@ module.exports = {
     library: 'olms',
     libraryTarget: 'umd',
     libraryExport: 'default',
+  },
+  resolve: {
+    fallback: {
+      'assert': path.join(__dirname, 'node_modules', 'nanoassert'),
+    },
   },
   externals: createExternals(),
 };


### PR DESCRIPTION
This pull request goes back to the `@mapbox/mapbox-gl-style-spec` package and creates bundles as small as possible.

This is a breaking change, because existing applications using imports other than `from 'ol-mapbox-style'` may not continue to work without modifications, depending on the used bundler.