### PR TITLE
Better OpenLayers integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,11 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 #### Properties
 
 *   `accessToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Access token for 'mapbox://' urls.
-*   `transformRequest` **function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [ResourceType](#resourcetype)): ([Request](https://developer.mozilla.org/Add-ons/SDK/High-Level_APIs/request) | [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))?** Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
+*   `transformRequest` **function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [ResourceType](#resourcetype)): ([Request](https://developer.mozilla.org/Add-ons/SDK/High-Level_APIs/request) | void)?** Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
     the url, adding headers or setting credentials options. Called with the url and the resource
-    type as arguments, this function is supposed to return a `Request` object. For `Tiles` and `GeoJSON`
-    resources, only the `url` of the returned request will be respected. To make more complex transforms
-    for those, you can return options for an `ol/source/VectorTile` or `ol/source/XYZ` (`Tiles` resource)
-    an `ol/source/Vector` (`GeoJSON` resource) instead of a \`Request'.
+    type as arguments, this function is supposed to return a `Request` object. Without a return value,
+    the original request will not be modified. For `Tiles` and `GeoJSON` resources, only the `url` of
+    the returned request will be respected.
 *   `styleUrl` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** URL of the Mapbox GL style. Required for styles that were provided
     as object, when they contain a relative sprite url.
 *   `accessTokenParam` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Access token param. For internal use.
@@ -171,13 +170,16 @@ Two additional properties will be set on the provided layer:
 
 #### Parameters
 
-*   `layer` **(VectorTileLayer | VectorLayer)** OpenLayers layer.
+*   `layer` **(VectorTileLayer | VectorLayer)** OpenLayers layer. When the layer has a source configured,
+    it will be modified to use the configuration from the glStyle's `source`. Options specified on the
+    layer's source will override those from the glStyle's `source`, except for `url`,
+    `tileUrlFunction` and `tileGrid` (exception: when the source projection is not `EPSG:3857`).
 *   `glStyle` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))** Mapbox Style object.
 *   `sourceOrLayers` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)?** `source` key or an array of layer `id`s from the
     Mapbox Style object. When a `source` key is provided, all layers for the
     specified source will be included in the style function. When layer `id`s
     are provided, they must be from layers that use the same source. When not provided, all
-    layers using the first layer's source will be rendered.
+    layers using the first source specified in the glStyle will be rendered.
 *   `optionsOrPath` **([Options](#options) | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Options. Alternatively the path of the style file
     (only required when a relative path is used for the `"sprite"` property of the style). (optional, default `{}`)
 *   `resolutions` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Resolutions for mapping resolution to zoom level.
@@ -266,7 +268,7 @@ sure that sprite image loading works:
     for the layer, and `mapbox-layers` will be an array of the `id`s of the
     `glStyle`'s layers.
 *   `glStyle` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))** Mapbox Style object.
-*   `source` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** `source` key or an array of layer `id`s
+*   `sourceOrLayers` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)** `source` key or an array of layer `id`s
     from the Mapbox Style object. When a `source` key is provided, all layers for
     the specified source will be included in the style function. When layer `id`s
     are provided, they must be from layers that use the same source.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
     type as arguments, this function is supposed to return a `Request` object. Without a return value,
     the original request will not be modified. For `Tiles` and `GeoJSON` resources, only the `url` of
     the returned request will be respected.
+*   `resolutions` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** Resolutions for mapping resolution to zoom level.
+    Only needed when working with non-standard tile grids or projections.
 *   `styleUrl` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** URL of the Mapbox GL style. Required for styles that were provided
     as object, when they contain a relative sprite url.
 *   `accessTokenParam` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Access token param. For internal use.
@@ -178,12 +180,12 @@ Two additional properties will be set on the provided layer:
 *   `sourceOrLayers` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)?** `source` key or an array of layer `id`s from the
     Mapbox Style object. When a `source` key is provided, all layers for the
     specified source will be included in the style function. When layer `id`s
-    are provided, they must be from layers that use the same source. When not provided, all
-    layers using the first source specified in the glStyle will be rendered.
+    are provided, they must be from layers that use the same source. When not provided or a falsey
+    value, all layers using the first source specified in the glStyle will be rendered.
 *   `optionsOrPath` **([Options](#options) | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** Options. Alternatively the path of the style file
     (only required when a relative path is used for the `"sprite"` property of the style). (optional, default `{}`)
-*   `resolutions` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Resolutions for mapping resolution to zoom level.
-    Only needed when working with non-standard tile grids or projections. (optional, default `undefined`)
+*   `resolutions` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>?** Resolutions for mapping resolution to zoom level.
+    Only needed when working with non-standard tile grids or projections.
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Promise which will be resolved when the style can be used
 for rendering.

--- a/examples/esri-transformrequest.js
+++ b/examples/esri-transformrequest.js
@@ -6,7 +6,7 @@ olms(
   'https://www.arcgis.com/sharing/rest/content/items/2afe5b807fa74006be6363fd243ffb30/resources/styles/root.json',
   {
     transformRequest(url, type) {
-      if (type === 'Tile') {
+      if (type === 'Tiles') {
         url = url.replace(
           'World_Basemap_v2/tile/',
           'World_Basemap_v2/VectorTileServer/tile/'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10480,9 +10480,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -23157,9 +23157,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pify": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "ol-mapbox-style",
   "version": "8.0.0-beta.0",
   "description": "Create OpenLayers maps from Mapbox Style objects",
+  "type": "module",
   "main": "dist/olms.js",
   "module": "dist/olms.es.js",
-  "type": "module",
+  "types": "dist/olms.d.ts",
   "exports": {
     ".": {
       "module": "./dist/olms.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,8 @@ function completeOptions(styleUrl, options) {
  * type as arguments, this function is supposed to return a `Request` object. Without a return value,
  * the original request will not be modified. For `Tiles` and `GeoJSON` resources, only the `url` of
  * the returned request will be respected.
+ * @property {Array<number>} [resolutions] Resolutions for mapping resolution to zoom level.
+ * Only needed when working with non-standard tile grids or projections.
  * @property {string} [styleUrl] URL of the Mapbox GL style. Required for styles that were provided
  * as object, when they contain a relative sprite url.
  * @property {string} [accessTokenParam='access_token'] Access token param. For internal use.
@@ -117,11 +119,11 @@ function completeOptions(styleUrl, options) {
  * @param {string|Array<string>} [sourceOrLayers] `source` key or an array of layer `id`s from the
  * Mapbox Style object. When a `source` key is provided, all layers for the
  * specified source will be included in the style function. When layer `id`s
- * are provided, they must be from layers that use the same source. When not provided, all
- * layers using the first source specified in the glStyle will be rendered.
+ * are provided, they must be from layers that use the same source. When not provided or a falsey
+ * value, all layers using the first source specified in the glStyle will be rendered.
  * @param {Options|string} [optionsOrPath={}] Options. Alternatively the path of the style file
  * (only required when a relative path is used for the `"sprite"` property of the style).
- * @param {Array<number>} [resolutions=undefined] Resolutions for mapping resolution to zoom level.
+ * @param {Array<number>} [resolutions] Resolutions for mapping resolution to zoom level.
  * Only needed when working with non-standard tile grids or projections.
  * @return {Promise} Promise which will be resolved when the style can be used
  * for rendering.

--- a/src/index.js
+++ b/src/index.js
@@ -225,8 +225,17 @@ export function applyStyle(
                     source.getProjection()
                   )
                 ) {
-                  targetSource.tileGrid = source.tileGrid;
+                  targetSource.tileGrid = source.getTileGrid();
                 }
+              }
+              if (
+                !isFinite(layer.getMaxResolution()) &&
+                !isFinite(layer.getMinZoom())
+              ) {
+                const tileGrid = layer.getSource().getTileGrid();
+                layer.setMaxResolution(
+                  tileGrid.getResolution(tileGrid.getMinZoom())
+                );
               }
             });
           } else {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import TileLayer from 'ol/layer/Tile.js';
 import VectorLayer from 'ol/layer/Vector.js';
 import VectorSource from 'ol/source/Vector.js';
 import VectorTileLayer from 'ol/layer/VectorTile.js';
-import VectorTileSource from 'ol/source/VectorTile.js';
+import VectorTileSource, {defaultLoadFunction} from 'ol/source/VectorTile.js';
 import View from 'ol/View.js';
 import applyStyleFunction, {
   _colorWithOpacity,
@@ -28,13 +28,13 @@ import {
   getGlStyle,
   getTileJson,
 } from './util.js';
-import {fromLonLat, getUserProjection} from 'ol/proj.js';
+import {equivalent, fromLonLat, getUserProjection} from 'ol/proj.js';
 import {getFonts} from './text.js';
 import {
   normalizeSourceUrl,
   normalizeSpriteUrl,
   normalizeStyleUrl,
-} from 'ol/layer/MapboxVector.js';
+} from './mapbox.js';
 
 /**
  * @param {string} styleUrl Style URL.
@@ -67,13 +67,12 @@ function completeOptions(styleUrl, options) {
 /**
  * @typedef {Object} Options
  * @property {string} [accessToken] Access token for 'mapbox://' urls.
- * @property {function(string, ResourceType): (Request|Object)} [transformRequest]
+ * @property {function(string, ResourceType): (Request|void)} [transformRequest]
  * Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
  * the url, adding headers or setting credentials options. Called with the url and the resource
- * type as arguments, this function is supposed to return a `Request` object. For `Tiles` and `GeoJSON`
- * resources, only the `url` of the returned request will be respected. To make more complex transforms
- * for those, you can return options for an `ol/source/VectorTile` or `ol/source/XYZ` (`Tiles` resource)
- * an `ol/source/Vector` (`GeoJSON` resource) instead of a `Request'.
+ * type as arguments, this function is supposed to return a `Request` object. Without a return value,
+ * the original request will not be modified. For `Tiles` and `GeoJSON` resources, only the `url` of
+ * the returned request will be respected.
  * @property {string} [styleUrl] URL of the Mapbox GL style. Required for styles that were provided
  * as object, when they contain a relative sprite url.
  * @property {string} [accessTokenParam='access_token'] Access token param. For internal use.
@@ -110,13 +109,16 @@ function completeOptions(styleUrl, options) {
  *  * `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
  *    included in the OpenLayers layer.
  *
- * @param {VectorTileLayer|VectorLayer} layer OpenLayers layer.
+ * @param {VectorTileLayer|VectorLayer} layer OpenLayers layer. When the layer has a source configured,
+ * it will be modified to use the configuration from the glStyle's `source`. Options specified on the
+ * layer's source will override those from the glStyle's `source`, except for `url`,
+ * `tileUrlFunction` and `tileGrid` (exception: when the source projection is not `EPSG:3857`).
  * @param {string|Object} glStyle Mapbox Style object.
  * @param {string|Array<string>} [sourceOrLayers] `source` key or an array of layer `id`s from the
  * Mapbox Style object. When a `source` key is provided, all layers for the
  * specified source will be included in the style function. When layer `id`s
  * are provided, they must be from layers that use the same source. When not provided, all
- * layers using the first layer's source will be rendered.
+ * layers using the first source specified in the glStyle will be rendered.
  * @param {Options|string} [optionsOrPath={}] Options. Alternatively the path of the style file
  * (only required when a relative path is used for the `"sprite"` property of the style).
  * @param {Array<number>} [resolutions=undefined] Resolutions for mapping resolution to zoom level.
@@ -149,7 +151,9 @@ export function applyStyle(
     styleUrl = glStyle;
   }
   if (styleUrl) {
-    styleUrl = normalizeStyleUrl(styleUrl, options.accessToken);
+    styleUrl = styleUrl.startsWith('data:')
+      ? location.href
+      : normalizeStyleUrl(styleUrl, options.accessToken);
     options = completeOptions(styleUrl, options);
   }
 
@@ -172,13 +176,12 @@ export function applyStyle(
 
         const type = layer instanceof VectorTileLayer ? 'vector' : 'geojson';
         if (!sourceOrLayers) {
-          const glLayer = glStyle.layers.find(function (layer) {
-            return layer.source && glStyle.sources[layer.source].type === type;
+          sourceId = Object.keys(glStyle.sources).find(function (key) {
+            return glStyle.sources[key].type === type;
           });
-          if (!glLayer) {
+          if (!sourceId) {
             return reject(new Error(`No ${type} source found in the glStyle.`));
           }
-          sourceId = glLayer.source;
         } else if (Array.isArray(sourceOrLayers)) {
           sourceId = glStyle.layers.find(function (layer) {
             return layer.id === sourceOrLayers[0];
@@ -188,22 +191,65 @@ export function applyStyle(
         }
 
         function assignSource() {
-          if (!layer.getSource()) {
-            if (layer instanceof VectorTileLayer) {
-              return setupVectorSource(
-                glStyle.sources[sourceId],
-                styleUrl,
-                options
-              ).then(function (source) {
+          if (layer instanceof VectorTileLayer) {
+            return setupVectorSource(
+              glStyle.sources[sourceId],
+              styleUrl,
+              options
+            ).then(function (source) {
+              const targetSource = layer.getSource();
+              if (!targetSource) {
                 layer.setSource(source);
-              });
-            } else {
-              layer.setSource(
-                setupGeoJSONSource(glStyle.sources[sourceId], styleUrl, options)
-              );
-              return Promise.resolve();
-            }
+              } else if (source !== targetSource) {
+                targetSource.setTileUrlFunction(source.getTileUrlFunction());
+                //@ts-ignore
+                if (!targetSource.format_) {
+                  //@ts-ignore
+                  targetSource.format_ = source.format_;
+                }
+                if (!targetSource.getAttributions()) {
+                  targetSource.setAttributions(source.getAttributions());
+                }
+                if (
+                  targetSource.getTileLoadFunction() === defaultLoadFunction
+                ) {
+                  targetSource.setTileLoadFunction(
+                    source.getTileLoadFunction()
+                  );
+                }
+                if (
+                  equivalent(
+                    targetSource.getProjection(),
+                    source.getProjection()
+                  )
+                ) {
+                  targetSource.tileGrid = source.tileGrid;
+                }
+              }
+            });
           } else {
+            const source = setupGeoJSONSource(
+              glStyle.sources[sourceId],
+              styleUrl,
+              options
+            );
+            const targetSource = /** @type {VectorSource} */ (
+              layer.getSource()
+            );
+            if (!targetSource) {
+              layer.setSource(source);
+            } else if (source !== targetSource) {
+              if (!targetSource.getAttributions()) {
+                targetSource.setAttributions(source.getAttributions());
+              }
+              //@ts-ignore
+              if (!targetSource.format_) {
+                //@ts-ignore
+                targetSource.format_ = source.getFormat();
+              }
+              //@ts-ignore
+              targetSource.url_ = source.getUrl();
+            }
             return Promise.resolve();
           }
         }
@@ -493,7 +539,6 @@ function setupRasterLayer(glSource, styleUrl, options) {
       const tileSize = glSource.tileSize || tileJson.tileSize || 512;
       const minZoom = tileJson.minzoom || 0;
       const maxZoom = tileJson.maxzoom || 22;
-      // Only works when using ES modules
       //@ts-ignore
       source.tileGrid = new TileGrid({
         origin: tileGrid.getOrigin(0),
@@ -505,17 +550,14 @@ function setupRasterLayer(glSource, styleUrl, options) {
         }).getResolutions(),
         tileSize: tileSize,
       });
-      source.setTileLoadFunction(function (tile, src) {
+      const getTileUrl = source.getTileUrlFunction();
+      source.setTileUrlFunction(function (tileCoord, pixelRatio, projection) {
+        let src = getTileUrl(tileCoord, pixelRatio, projection);
         if (src.indexOf('{bbox-epsg-3857}') != -1) {
-          const bbox = source
-            .getTileGrid()
-            .getTileCoordExtent(tile.getTileCoord());
+          const bbox = source.getTileGrid().getTileCoordExtent(tileCoord);
           src = src.replace('{bbox-epsg-3857}', bbox.toString());
         }
-        const img = /** @type {import("ol/ImageTile").default} */ (
-          tile
-        ).getImage();
-        /** @type {HTMLImageElement} */ (img).src = src;
+        return src;
       });
       layer.setSource(source);
     })
@@ -546,9 +588,6 @@ function setupGeoJSONSource(glSource, styleUrl, options) {
       const transformed = options.transformRequest(geoJsonUrl, 'GeoJSON');
       if (transformed instanceof Request) {
         geoJsonUrl = encodeURI(transformed.url);
-      } else {
-        assign(sourceOptions, transformed);
-        geoJsonUrl = undefined;
       }
     }
     sourceOptions.url = geoJsonUrl;
@@ -735,7 +774,9 @@ export default function olms(map, style, options = {}) {
   }
 
   if (typeof style === 'string') {
-    const styleUrl = normalizeStyleUrl(style, options.accessToken);
+    const styleUrl = style.startsWith('data:')
+      ? location.href
+      : normalizeStyleUrl(style, options.accessToken);
     options = completeOptions(styleUrl, options);
 
     promise = new Promise(function (resolve, reject) {

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -1,0 +1,80 @@
+const mapboxBaseUrl = 'https://api.mapbox.com';
+
+/**
+ * Gets the path from a mapbox:// URL.
+ * @param {string} url The Mapbox URL.
+ * @return {string} The path.
+ * @private
+ */
+export function getMapboxPath(url) {
+  const startsWith = 'mapbox://';
+  if (url.indexOf(startsWith) !== 0) {
+    return '';
+  }
+  return url.slice(startsWith.length);
+}
+
+/**
+ * Turns mapbox:// sprite URLs into resolvable URLs.
+ * @param {string} url The sprite URL.
+ * @param {string} token The access token.
+ * @param {string} styleUrl The style URL.
+ * @return {string} A resolvable URL.
+ * @private
+ */
+export function normalizeSpriteUrl(url, token, styleUrl) {
+  const mapboxPath = getMapboxPath(url);
+  if (!mapboxPath) {
+    return decodeURI(new URL(url, styleUrl).href);
+  }
+  const startsWith = 'sprites/';
+  if (mapboxPath.indexOf(startsWith) !== 0) {
+    throw new Error(`unexpected sprites url: ${url}`);
+  }
+  const sprite = mapboxPath.slice(startsWith.length);
+
+  return `${mapboxBaseUrl}/styles/v1/${sprite}/sprite?access_token=${token}`;
+}
+
+/**
+ * Turns mapbox:// style URLs into resolvable URLs.
+ * @param {string} url The style URL.
+ * @param {string} token The access token.
+ * @return {string} A resolvable URL.
+ * @private
+ */
+export function normalizeStyleUrl(url, token) {
+  const mapboxPath = getMapboxPath(url);
+  if (!mapboxPath) {
+    return decodeURI(new URL(url, location.href).href);
+  }
+  const startsWith = 'styles/';
+  if (mapboxPath.indexOf(startsWith) !== 0) {
+    throw new Error(`unexpected style url: ${url}`);
+  }
+  const style = mapboxPath.slice(startsWith.length);
+
+  return `${mapboxBaseUrl}/styles/v1/${style}?&access_token=${token}`;
+}
+
+/**
+ * Turns mapbox:// source URLs into vector tile URL templates.
+ * @param {string} url The source URL.
+ * @param {string} token The access token.
+ * @param {string} tokenParam The access token key.
+ * @param {string} styleUrl The style URL.
+ * @return {string} A vector tile template.
+ * @private
+ */
+export function normalizeSourceUrl(url, token, tokenParam, styleUrl) {
+  const urlObject = new URL(url, styleUrl);
+  const mapboxPath = getMapboxPath(url);
+  if (!mapboxPath) {
+    if (!token) {
+      return decodeURI(urlObject.href);
+    }
+    urlObject.searchParams.set(tokenParam, token);
+    return decodeURI(urlObject.href);
+  }
+  return `https://{a-d}.tiles.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}.vector.pbf?access_token=${token}`;
+}

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -279,7 +279,7 @@ export function recordStyleLayer(record) {
  * for the layer, and `mapbox-layers` will be an array of the `id`s of the
  * `glStyle`'s layers.
  * @param {string|Object} glStyle Mapbox Style object.
- * @param {string|Array<string>} source `source` key or an array of layer `id`s
+ * @param {string|Array<string>} sourceOrLayers `source` key or an array of layer `id`s
  * from the Mapbox Style object. When a `source` key is provided, all layers for
  * the specified source will be included in the style function. When layer `id`s
  * are provided, they must be from layers that use the same source.
@@ -302,7 +302,7 @@ export function recordStyleLayer(record) {
 export default function (
   olLayer,
   glStyle,
-  source,
+  sourceOrLayers,
   resolutions = defaultResolutions,
   spriteData,
   spriteImageUrl,
@@ -361,8 +361,8 @@ export default function (
     const layer = allLayers[i];
     const layerId = layer.id;
     if (
-      (typeof source == 'string' && layer.source == source) ||
-      source.indexOf(layerId) !== -1
+      (typeof sourceOrLayers == 'string' && layer.source == sourceOrLayers) ||
+      sourceOrLayers.indexOf(layerId) !== -1
     ) {
       const sourceLayer = layer['source-layer'];
       if (!mapboxSource) {
@@ -377,6 +377,10 @@ export default function (
             `Source "${mapboxSource}" is not of type "vector" or "geojson", but "${type}"`
           );
         }
+      } else if (layer.source !== mapboxSource) {
+        throw new Error(
+          `Layer "${layerId}" does not use source "${mapboxSource}`
+        );
       }
       let layers = layersBySourceLayer[sourceLayer];
       if (!layers) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,5 @@
 import {assign} from 'ol/obj.js';
-import {normalizeSourceUrl, normalizeStyleUrl} from 'ol/layer/MapboxVector.js';
+import {normalizeSourceUrl, normalizeStyleUrl} from './mapbox.js';
 
 export function deg2rad(degrees) {
   return (degrees * Math.PI) / 180;

--- a/src/util.js
+++ b/src/util.js
@@ -56,7 +56,7 @@ export function fetchResource(resourceType, url, options = {}) {
     return pendingRequests[url];
   } else {
     const request = options.transformRequest
-      ? options.transformRequest(url, resourceType)
+      ? options.transformRequest(url, resourceType) || new Request(url)
       : new Request(url);
     const pendingRequest = fetch(request)
       .then(function (response) {
@@ -136,9 +136,6 @@ export function getTileJson(glSource, styleUrl, options = {}) {
                 );
                 if (transformedRequest instanceof Request) {
                   normalizedTileUrl = decodeURI(transformedRequest.url);
-                } else {
-                  tileJson.olSourceOptions = transformedRequest;
-                  break;
                 }
               }
               tileJson.tiles[i] = normalizedTileUrl;

--- a/test/applyStyle.test.js
+++ b/test/applyStyle.test.js
@@ -23,7 +23,7 @@ describe('applyStyle with source creation', function () {
       try {
         should(layer.getSource()).be.an.instanceOf(VectorSource);
         should(layer.getSource().getUrl()).equal(
-          'http://localhost:9876/fixtures/states.geojson'
+          `${location.origin}/fixtures/states.geojson`
         );
         should(layer.getStyle()).be.an.instanceOf(Function);
         done();
@@ -45,7 +45,7 @@ describe('applyStyle with source creation', function () {
       try {
         should(layer.getSource()).be.an.instanceOf(VectorSource);
         should(layer.getSource().getUrl()).equal(
-          'http://localhost:9876/fixtures/states.geojson?foo=bar'
+          `${location.origin}/fixtures/states.geojson?foo=bar`
         );
         should(layer.getStyle()).be.an.instanceOf(Function);
         done();
@@ -54,36 +54,36 @@ describe('applyStyle with source creation', function () {
       }
     });
   });
-  it('uses source options from the transformRequest option', function (done) {
-    const layer = new VectorLayer();
-    let loader;
-    applyStyle(layer, '/fixtures/geojson.json', 'states', {
-      transformRequest: function (url, type) {
-        if (type === 'GeoJSON') {
-          loader = function (extent, resolution, projection, success, failure) {
-            fetch(url)
-              .then((response) => {
-                response.json().then((json) => {
-                  const features = this.getFormat().readFeatures(json, {
-                    featureProjection: projection,
-                  });
-                  success(features);
-                });
-              })
-              .catch((error) => {
-                failure(error);
-              });
-          };
-          return {
-            loader: loader,
-          };
-        }
-        return new Request(url);
-      },
-    }).then(function () {
+  it('respects source options from layer config', function (done) {
+    const source = new VectorSource();
+    const layer = new VectorLayer({
+      source: source,
+    });
+    const loader = function (extent, resolution, projection, success, failure) {
+      fetch(/** @type {string} */ (layer.getSource().getUrl()))
+        .then((response) => {
+          response.json().then((json) => {
+            const features = this.getFormat().readFeatures(json, {
+              featureProjection: projection,
+            });
+            success(
+              /** @type {Array<import("ol/Feature").default>} */ (features)
+            );
+          });
+        })
+        .catch((error) => {
+          failure();
+        });
+    };
+    layer.getSource().setLoader(loader);
+
+    applyStyle(layer, '/fixtures/geojson.json', 'states').then(function () {
       try {
-        should(layer.getSource()).be.an.instanceOf(VectorSource);
-        should(layer.getSource().getUrl()).equal(undefined);
+        should(layer.getSource()).equal(source);
+        should(layer.getSource().getUrl()).equal(
+          `${location.origin}/fixtures/states.geojson`
+        );
+        //@ts-ignore
         should(layer.getSource().loader_).equal(loader);
         should(layer.getStyle()).be.an.instanceOf(Function);
         done();
@@ -99,7 +99,7 @@ describe('applyStyle with source creation', function () {
         try {
           should(layer.getSource()).be.an.instanceOf(VectorTileSource);
           should(layer.getSource().getUrls()[0]).equal(
-            'http://localhost:9876/fixtures/osm-liberty/tiles/v3/{z}/{x}/{y}.pbf'
+            `${location.origin}/fixtures/osm-liberty/tiles/v3/{z}/{x}/{y}.pbf`
           );
           should(layer.getStyle()).be.an.instanceOf(Function);
           done();
@@ -125,7 +125,7 @@ describe('applyStyle with source creation', function () {
         try {
           should(layer.getSource()).be.an.instanceOf(VectorTileSource);
           should(layer.getSource().getUrls()[0]).equal(
-            'http://localhost:9876/fixtures/osm-liberty/tiles/v3/{z}/{x}/{y}.pbf?foo=bar'
+            `${location.origin}/fixtures/osm-liberty/tiles/v3/{z}/{x}/{y}.pbf?foo=bar`
           );
           should(layer.getStyle()).be.an.instanceOf(Function);
           done();
@@ -137,39 +137,31 @@ describe('applyStyle with source creation', function () {
         done(e);
       });
   });
-  it('uses source options from the transformRequest option', function (done) {
-    const layer = new VectorTileLayer();
-    let tileLoadFunction;
-    applyStyle(layer, '/fixtures/osm-liberty/style.json', 'openmaptiles', {
-      transformRequest(url, type) {
-        if (type === 'Tiles') {
-          tileLoadFunction = function (tile, url) {
-            tile.setLoader(function (extent, resolution, projection) {
-              fetch(url + '?foo=bar').then(function (response) {
-                response.arrayBuffer().then(function (data) {
-                  const format = tile.getFormat();
-                  const features = format.readFeatures(data, {
-                    extent: extent,
-                    featureProjection: projection,
-                  });
-                  tile.setFeatures(features);
-                });
-              });
+  it('respects source options from layer config', function (done) {
+    const source = new VectorTileSource({});
+    const layer = new VectorTileLayer({
+      source: source,
+    });
+    const loader = function (tile, url) {
+      tile.setLoader(function (extent, resolution, projection) {
+        fetch(url + '?foo=bar').then(function (response) {
+          response.arrayBuffer().then(function (data) {
+            const format = tile.getFormat();
+            const features = format.readFeatures(data, {
+              extent: extent,
+              featureProjection: projection,
             });
-          };
-          return {
-            tileLoadFunction: tileLoadFunction,
-          };
-        }
-        return new Request(url);
-      },
-    })
+            tile.setFeatures(features);
+          });
+        });
+      });
+    };
+    layer.getSource().setTileLoadFunction(loader);
+    applyStyle(layer, '/fixtures/osm-liberty/style.json', 'openmaptiles')
       .then(function () {
         try {
-          should(layer.getSource()).be.an.instanceOf(VectorTileSource);
-          should(layer.getSource().getTileLoadFunction()).equal(
-            tileLoadFunction
-          );
+          should(layer.getSource()).equal(source);
+          should(layer.getSource().getTileLoadFunction()).equal(loader);
           should(layer.getStyle()).be.an.instanceOf(Function);
           done();
         } catch (e) {

--- a/test/applyStyle.test.js
+++ b/test/applyStyle.test.js
@@ -174,6 +174,48 @@ describe('applyStyle with source creation', function () {
   });
 });
 
+describe('maxResolution', function () {
+  const glStyle = {
+    version: 8,
+    sources: {
+      'foo': {
+        tiles: ['/fixtures/{z}-{x}-{y}.vector.pbf'],
+        type: 'vector',
+        minzoom: 6,
+      },
+    },
+    layers: [],
+  };
+
+  it('accepts minZoom from configuration', function (done) {
+    const layer = new VectorTileLayer({
+      minZoom: 5,
+    });
+    applyStyle(layer, glStyle)
+      .then(function () {
+        should(layer.getMaxResolution()).equal(Infinity);
+        done();
+      })
+      .catch(function (e) {
+        done(e);
+      });
+  });
+
+  it('uses minZoom from source', function (done) {
+    const layer = new VectorTileLayer();
+    applyStyle(layer, glStyle)
+      .then(function () {
+        should(layer.getMaxResolution()).equal(
+          layer.getSource().getTileGrid().getResolution(6)
+        );
+        done();
+      })
+      .catch(function (e) {
+        done(e);
+      });
+  });
+});
+
 describe('applyStyle style argument validation', function () {
   const source = 'openmaptiles';
   const layer = new VectorTileLayer();

--- a/test/mapbox.test.js
+++ b/test/mapbox.test.js
@@ -1,0 +1,121 @@
+import should from 'should';
+import {
+  getMapboxPath,
+  normalizeSourceUrl,
+  normalizeSpriteUrl,
+  normalizeStyleUrl,
+} from '../src/mapbox.js';
+
+describe('Mapbox utilities', function () {
+  describe('getMapboxPath()', () => {
+    const cases = [
+      {
+        url: 'mapbox://path/to/resource',
+        expected: 'path/to/resource',
+      },
+      {
+        url: 'mapbox://path/to/resource?query',
+        expected: 'path/to/resource?query',
+      },
+      {
+        url: 'https://example.com/resource',
+        expected: '',
+      },
+    ];
+
+    for (const c of cases) {
+      it(`works for ${c.url}`, () => {
+        should(getMapboxPath(c.url)).equal(c.expected);
+      });
+    }
+  });
+
+  describe('normalizeStyleUrl()', () => {
+    const cases = [
+      {
+        url: 'mapbox://styles/mapbox/bright-v9',
+        expected:
+          'https://api.mapbox.com/styles/v1/mapbox/bright-v9?&access_token=test-token',
+      },
+      {
+        url: 'https://example.com/style',
+        expected: 'https://example.com/style',
+      },
+    ];
+
+    const token = 'test-token';
+    for (const c of cases) {
+      it(`works for ${c.url}`, () => {
+        should(normalizeStyleUrl(c.url, token)).equal(c.expected);
+      });
+    }
+  });
+
+  describe('normalizeSpriteUrl()', () => {
+    const cases = [
+      {
+        url: 'mapbox://sprites/mapbox/bright-v9',
+        expected:
+          'https://api.mapbox.com/styles/v1/mapbox/bright-v9/sprite?access_token=test-token',
+      },
+      {
+        url: 'https://example.com/sprite',
+        expected: 'https://example.com/sprite',
+      },
+      {
+        url: '../sprite',
+        expected: 'https://example.com:8000/sprite',
+      },
+      {
+        url: '/sprite',
+        expected: 'https://example.com:8000/sprite',
+      },
+      {
+        url: './sprite',
+        expected: 'https://example.com:8000/mystyle/sprite',
+      },
+    ];
+
+    const token = 'test-token';
+    for (const c of cases) {
+      it(`works for ${c.url}`, () => {
+        should(
+          normalizeSpriteUrl(
+            c.url,
+            token,
+            'https://example.com:8000/mystyle/style.json'
+          )
+        ).equal(c.expected);
+      });
+    }
+  });
+
+  describe('normalizeSourceUrl()', () => {
+    const cases = [
+      {
+        url: 'mapbox://mapbox.mapbox-streets-v7',
+        expected:
+          'https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=test-token',
+      },
+      {
+        url: 'https://example.com/source/{z}/{x}/{y}.pbf',
+        expected: 'https://example.com/source/{z}/{x}/{y}.pbf?token=test-token',
+      },
+      {
+        url: 'https://example.com/source/{z}/{x}/{y}.pbf?foo=bar',
+        expected:
+          'https://example.com/source/{z}/{x}/{y}.pbf?foo=bar&token=test-token',
+      },
+    ];
+
+    const token = 'test-token';
+    const tokenParam = 'token';
+    for (const c of cases) {
+      it(`works for ${c.url}`, () => {
+        should(
+          normalizeSourceUrl(c.url, token, tokenParam, location.href)
+        ).equal(c.expected);
+      });
+    }
+  });
+});

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -7,7 +7,8 @@
     "allowJs": true,
     "importHelpers": false,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
   },
   "include": [
     "./src/**/*.js"

--- a/webpack.config.olms.cjs
+++ b/webpack.config.olms.cjs
@@ -99,9 +99,12 @@ const createConfig = (type) => ({
     },
   },
   externals: createExternals(),
-  experiments: {
-    outputModule: type === 'es.js',
-  },
 });
 
-module.exports = [createConfig('js'), createConfig('es.js')];
+module.exports = [
+  createConfig('js'),
+  Object.assign(createConfig('es.js'), {
+    experiments: {outputModule: true},
+    optimization: {minimize: false},
+  }),
+];

--- a/webpack.config.olms.cjs
+++ b/webpack.config.olms.cjs
@@ -18,7 +18,6 @@ const externals = {
   'ol/Map.js': 'ol.Map',
   'ol/View.js': 'ol.View',
   'ol/Observable.js': 'ol.Observable',
-  'ol/layer/MapboxVector.js': 'ol.layer.MapboxVector',
   'ol/layer/Tile.js': 'ol.layer.Tile',
   'ol/layer/Vector.js': 'ol.layer.Vector',
   'ol/layer/VectorTile.js': 'ol.layer.VectorTile',


### PR DESCRIPTION
This pull request improves the OpenLayers integration, with the goal of making `ol/layer/MapboxVector` very lightweight:

* Handle "first source" the same way as `ol/layer/MapboxVector` does
* Respect configured sources and modify them, instead of creating a new source
* Remove "source configuration" return type from the `transformRequest` option, because this can now be handled with a configured source.
* Provide Mapbox url utilities here, instead of relying on a circular OpenLayers dependency.
* Do not include transpiled sources in the bundle, instead do not minify the esm bundle for easier debugging.