### PR TITLE
Google fonts without dependency and with better fallback/default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1",
-        "webfont-matcher": "^1.1.0"
+        "mapbox-to-css-font": "^2.4.1"
       },
       "devDependencies": {
         "@types/arcgis-rest-api": "^10.4.4",
@@ -10370,7 +10369,8 @@
     "node_modules/webfont-matcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -18963,7 +18963,8 @@
     "webfont-matcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
+      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc=",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   },
   "dependencies": {
     "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-    "mapbox-to-css-font": "^2.4.1",
-    "webfont-matcher": "^1.1.0"
+    "mapbox-to-css-font": "^2.4.1"
   },
   "devDependencies": {
     "@types/arcgis-rest-api": "^10.4.4",

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1036,6 +1036,9 @@ export function stylefunction(
             textSize,
             textLineHeight
           );
+          if (!font.includes('sans-serif')) {
+            font += ',sans-serif';
+          }
           letterSpacing = getValue(
             layer,
             'layout',

--- a/src/text.js
+++ b/src/text.js
@@ -157,14 +157,21 @@ const processedFontFamilies = {};
 export function getFonts(fonts) {
   const fontsKey = fonts.toString();
   if (fontsKey in processedFontFamilies) {
-    return fonts;
+    return processedFontFamilies[fontsKey];
   }
-  const googleFontDescriptions = fonts.map(function (font) {
+  const googleFontDescriptions = [];
+  for (let i = 0, ii = fonts.length; i < ii; ++i) {
+    fonts[i] = fonts[i].replace('Arial Unicode MS', 'Arial');
+    const font = fonts[i];
     const cssFont = mb2css(font, 1);
     registerFont(cssFont);
     const parts = cssFont.split(' ');
-    return [parts.slice(3).join(' ').replace(/"/g, ''), parts[1], parts[0]];
-  });
+    googleFontDescriptions.push([
+      parts.slice(3).join(' ').replace(/"/g, ''),
+      parts[1],
+      parts[0],
+    ]);
+  }
   for (let i = 0, ii = googleFontDescriptions.length; i < ii; ++i) {
     const googleFontDescription = googleFontDescriptions[i];
     const family = googleFontDescription[0];
@@ -189,6 +196,6 @@ export function getFonts(fonts) {
       }
     }
   }
-  processedFontFamilies[fontsKey] = true;
+  processedFontFamilies[fontsKey] = fonts;
   return fonts;
 }


### PR DESCRIPTION
This pull request removes the webfont-matcher dependency. Instead, Google fonts will only be loaded on demand, i.e. when they are not already available in the browser. In addition, a `sans-serif` fallback is added to all font strings, and "Arial Unicode MS" is replaced with "Arial" to match the common CSS name for the Arial font.

Fixes #448.