### PR TITLE
Avoid duplicate source creation

### DIFF
--- a/examples/esri-transformrequest.js
+++ b/examples/esri-transformrequest.js
@@ -6,13 +6,11 @@ olms(
   'https://www.arcgis.com/sharing/rest/content/items/2afe5b807fa74006be6363fd243ffb30/resources/styles/root.json',
   {
     transformRequest(url, type) {
-      if (type === 'Tiles') {
-        url = url.replace(
-          'World_Basemap_v2/tile/',
-          'World_Basemap_v2/VectorTileServer/tile/'
+      if (type === 'Source') {
+        return new Request(
+          url.replace('/VectorTileServer', '/VectorTileServer/')
         );
       }
-      return new Request(url);
     },
   }
 );


### PR DESCRIPTION
By adding an `mapbox-source` property on sources created by ol-mapbox-style, we can avoid that sources are created twice. Transforming the source url only once allows proper caching in the TileJSON cache, which was previously useless when the `transformRequest` config option was used.