### PR TITLE
Avoid unnecessary TileJSON fetch

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -107,7 +107,7 @@ export function getTileJson(glSource, styleUrl, options = {}) {
   let promise = tilejsonCache[cacheKey];
   if (!promise || options.transformRequest) {
     const url = glSource.url;
-    if (url) {
+    if (url && !glSource.tiles) {
       let normalizedSourceUrl = normalizeSourceUrl(
         url,
         options.accessToken,


### PR DESCRIPTION
Currently we fetch a TileJSON as soon as we have a `url` in the source definition. But Esri style docs sometimes contain both a `url` and `tiles`. In this case, we do not need to fetch the TileJSON, and can use the information from the source directly.