### PR TITLE
Call transformRequest for sprite image URLs

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -59,7 +59,7 @@ import {
  * @property {string} [accessTokenParam='access_token'] Access token param. For internal use.
  */
 
-/** @typedef {'Style'|'Source'|'Sprite'|'Tiles'|'GeoJSON'} ResourceType */
+/** @typedef {'Style'|'Source'|'Sprite'|'SpriteImage'|'Tiles'|'GeoJSON'} ResourceType */
 /** @typedef {import("ol/layer/Layer").default} Layer */
 /** @typedef {import("ol/source/Source").default} Source */
 
@@ -330,6 +330,15 @@ export function applyStyle(
                 sizeFactor +
                 '.png' +
                 sprite.search;
+              if (options.transformRequest) {
+                const transformed = options.transformRequest(
+                  spriteImageUrl,
+                  'SpriteImage'
+                );
+                if (transformed instanceof Request) {
+                  spriteImageUrl = encodeURI(transformed.url);
+                }
+              }
               onChange();
             })
             .catch(function (err) {

--- a/test/applyStyle.test.js
+++ b/test/applyStyle.test.js
@@ -386,3 +386,38 @@ describe('applyStyle functionality', function () {
     );
   });
 });
+
+describe('applyStyle supports transformRequest object', function () {
+  it('applies transformRequest to all request types', function (done) {
+    const layer = new VectorTileLayer();
+    const expectedRequestTypes = new Set([
+      'Style',
+      'Sprite',
+      'SpriteImage',
+      'Source',
+      'Tiles',
+    ]);
+    const seenRequestTypes = new Set();
+    applyStyle(layer, '/fixtures/hot-osm/hot-osm.json', '', {
+      transformRequest: function (url, type) {
+        seenRequestTypes.add(type);
+        return new Request(url);
+      },
+    })
+      .then(function () {
+        should.deepEqual(
+          expectedRequestTypes,
+          seenRequestTypes,
+          `Request types seen by transformRequest: ${Array.from(
+            seenRequestTypes
+          )} do not match those expected for a Vector Tile style: ${Array.from(
+            expectedRequestTypes
+          )}`
+        );
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+});

--- a/test/applyStyle.test.js
+++ b/test/applyStyle.test.js
@@ -388,7 +388,7 @@ describe('applyStyle functionality', function () {
 });
 
 describe('applyStyle supports transformRequest object', function () {
-  it('applies transformRequest to all request types', function (done) {
+  it('applies transformRequest to all Vector Tile request types', function (done) {
     const layer = new VectorTileLayer();
     const expectedRequestTypes = new Set([
       'Style',
@@ -411,6 +411,32 @@ describe('applyStyle supports transformRequest object', function () {
           `Request types seen by transformRequest: ${Array.from(
             seenRequestTypes
           )} do not match those expected for a Vector Tile style: ${Array.from(
+            expectedRequestTypes
+          )}`
+        );
+        done();
+      })
+      .catch(function (error) {
+        done(error);
+      });
+  });
+  it('applies transformRequest to GeoJSON request types', function (done) {
+    const layer = new VectorLayer();
+    const expectedRequestTypes = new Set(['Style', 'GeoJSON']);
+    const seenRequestTypes = new Set();
+    applyStyle(layer, '/fixtures/geojson.json', '', {
+      transformRequest: function (url, type) {
+        seenRequestTypes.add(type);
+        return new Request(url);
+      },
+    })
+      .then(function () {
+        should.deepEqual(
+          expectedRequestTypes,
+          seenRequestTypes,
+          `Request types seen by transformRequest: ${Array.from(
+            seenRequestTypes
+          )} do not match those expected for a GeoJSON style: ${Array.from(
             expectedRequestTypes
           )}`
         );


### PR DESCRIPTION
Resolves #617 by calling `transformRequest` for the `spriteImageUrl` when `transformRequest` is passed as an option to `applyStyle`.

Tests verify that `transformRequest` is being called for each of the expected `ResourceType` values.