### PR TITLE
Render background after content so it doesn't get clipped away

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -439,10 +439,13 @@ function setBackground(mapOrLayer, layer, options) {
     if (color) {
       const context = e.context;
       const alpha = context.globalAlpha;
+      const gobalCompositeOperation = context.globalCompositeOperation;
       context.globalAlpha = 1;
+      context.globalCompositeOperation = 'destination-over';
       context.fillStyle = color;
       context.fillRect(0, 0, e.context.canvas.width, e.context.canvas.height);
       context.globalAlpha = alpha;
+      context.globalCompositeOperation = gobalCompositeOperation;
     }
     backgroundRendered = true;
   }
@@ -451,16 +454,16 @@ function setBackground(mapOrLayer, layer, options) {
     // map or layer group
     const layers = mapOrLayer.getLayers();
     layers.forEach(function (layer) {
-      layer.on('prerender', renderBackground);
+      layer.on('postrender', renderBackground);
     });
     layers.on('add', function (e) {
-      e.element.on('prerender', renderBackground);
+      e.element.on('postrender', renderBackground);
     });
     layers.on('remove', function (e) {
-      e.element.un('prerender', renderBackground);
+      e.element.un('postrender', renderBackground);
     });
   } else {
-    mapOrLayer.on('prerender', renderBackground);
+    mapOrLayer.on('postrender', renderBackground);
   }
 }
 

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -575,7 +575,7 @@ describe('ol-mapbox-style', function () {
       });
       let backgroundColor;
       map.addLayer(layer);
-      layer.on('prerender', function (e) {
+      layer.on('postrender', function (e) {
         backgroundColor = Array.from(e.context.getImageData(0, 0, 1, 1).data);
       });
       map.renderSync();
@@ -598,7 +598,7 @@ describe('ol-mapbox-style', function () {
       layerGroup
         .getLayers()
         .item(0)
-        .on('prerender', function (e) {
+        .on('postrender', function (e) {
           backgroundColor = Array.from(e.context.getImageData(0, 0, 1, 1).data);
         });
       map.renderSync();
@@ -611,7 +611,7 @@ describe('ol-mapbox-style', function () {
       map.addLayer(layer);
       applyBackground(layer, backgroundStyle);
       let backgroundColor;
-      layer.on('prerender', function (e) {
+      layer.on('postrender', function (e) {
         backgroundColor = Array.from(e.context.getImageData(0, 0, 1, 1).data);
       });
       map.renderSync();
@@ -627,7 +627,7 @@ describe('ol-mapbox-style', function () {
       });
       map.addLayer(layer);
       let backgroundColor;
-      layer.on('prerender', function (e) {
+      layer.on('postrender', function (e) {
         backgroundColor = Array.from(e.context.getImageData(0, 0, 1, 1).data);
       });
       map.renderSync();
@@ -640,7 +640,7 @@ describe('ol-mapbox-style', function () {
       map.addLayer(layer);
       applyBackground(layer, backgroundNoneStyle);
       let backgroundColor;
-      layer.on('prerender', function (e) {
+      layer.on('postrender', function (e) {
         backgroundColor = Array.from(e.context.getImageData(0, 0, 1, 1).data);
       });
       map.renderSync();
@@ -654,7 +654,7 @@ describe('ol-mapbox-style', function () {
           });
           map.addLayer(layer);
           let backgroundColor;
-          layer.on('prerender', function (e) {
+          layer.on('postrender', function (e) {
             backgroundColor = Array.from(
               e.context.getImageData(0, 0, 1, 1).data
             );


### PR DESCRIPTION
Currently, the new way to render background fails on vector tile layers because of clipping in the OpenLayers renderer. By applying the background after other content, this can be avoided.