### PR TITLE
Support build on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "concat-md": "^0.5.0",
         "copy-webpack-plugin": "^11.0.0",
         "coverage-istanbul-loader": "^3.0.5",
+        "cross-env": "^7.0.3",
         "css-loader": "^6.5.1",
         "deep-freeze": "0.0.1",
         "eslint": "^8.2.0",
@@ -2755,6 +2756,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {
@@ -13508,6 +13527,15 @@
       "dev": true,
       "requires": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.config.examples.cjs",
     "prepare": "npm run doc && npm run build",
-    "build": "tsc --project tsconfig-build.json && rollup -c && esm=true rollup -c && webpack-cli --mode=production --config ./webpack.config.examples.cjs",
+    "build": "tsc --project tsconfig-build.json && rollup -c && cross-env esm=true rollup -c && webpack-cli --mode=production --config ./webpack.config.examples.cjs",
     "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-plugin-missing-exports src/index.js --readme none --excludeExternals --preserveAnchorCasing --hideBreadcrumbs --disableSources --tsconfig tsconfig-typecheck.json && npx concat-md docs --hide-anchor-links=false | npx add-text-to-markdown README.md --section \"API\" --write",
     "karma": "karma start test/karma.conf.cjs",
     "lint": "eslint test examples src",
@@ -57,6 +57,7 @@
     "concat-md": "^0.5.0",
     "copy-webpack-plugin": "^11.0.0",
     "coverage-istanbul-loader": "^3.0.5",
+    "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
     "deep-freeze": "0.0.1",
     "eslint": "^8.2.0",


### PR DESCRIPTION
Build/install on windows fails because of "esm=true". Fix by using cross-env.