### PR TITLE
Make raster-opacity less sticky

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -685,8 +685,13 @@ function setupGeoJSONLayer(glSource, styleUrl, options) {
 function prerenderRasterLayer(glLayer, layer, functionCache) {
   let zoom = null;
   return function (event) {
-    if (event.frameState.viewState.zoom !== zoom) {
+    if (
+      glLayer.paint &&
+      'raster-opacity' in glLayer.paint &&
+      event.frameState.viewState.zoom !== zoom
+    ) {
       zoom = event.frameState.viewState.zoom;
+      delete functionCache[glLayer.id];
       updateRasterLayerProperties(glLayer, layer, zoom, functionCache);
     }
   };

--- a/test/fixtures/wms.json
+++ b/test/fixtures/wms.json
@@ -37,7 +37,10 @@
     {
       "id": "states-wms",
       "type": "raster",
-      "source": "states"
+      "source": "states",
+      "paint": {
+        "raster-opacity": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
Currently it is barely impossible to override a raster layer's opacity by using `layer.setOpacity()` in OpenLayers.

This pull request makes it so when no `raster-opacity` paint property is set on the Mapbox raster layer, `layer.setOpacity() can always be used, and its value won't get overridden on zoom changes. When `raster-opacity` is set, it can be changed in the Mapbox Style object, and will be applied on the next render cycle.

Fixes #675.