### PR TITLE
fix: mapbox satellite and streets v8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 dist
 docs
 coverage
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 docs
 coverage
+.idea

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="433ee718-ec73-4307-9728-02f4d2909540" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/src/mapbox.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/mapbox.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/util.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/util.js" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2ElBQGCcgrRCwU4hpCe7Qi1v00t" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "last_opened_file_path": "/Users/bovandersteene/project/sympheny/ol-mapbox-style",
+    "node.js.detected.package.eslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ts.external.directory.path": "/Users/bovandersteene/project/sympheny/ol-mapbox-style/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RunManager" selected="JavaScript Debug.mapbox.html">
+    <configuration name="mapbox.html" type="JavascriptDebugType" temporary="true" nameIsGenerated="true" uri="http://localhost:63342/ol-mapbox-style/dist/examples/mapbox.html" useBuiltInWebServerPort="true">
+      <method v="2" />
+    </configuration>
+    <configuration name="satelite.html" type="JavascriptDebugType" temporary="true" nameIsGenerated="true" uri="http://localhost:63342/ol-mapbox-style/examples/satelite.html" useBuiltInWebServerPort="true">
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="JavaScript Debug.mapbox.html" />
+        <item itemvalue="JavaScript Debug.satelite.html" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="433ee718-ec73-4307-9728-02f4d2909540" name="Changes" comment="" />
+      <created>1663160273175</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1663160273175</updated>
+      <workItem from="1663160277650" duration="8810000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -77,11 +77,9 @@ export function normalizeSourceUrl(url, token, tokenParam, styleUrl) {
     return decodeURI(urlObject.href);
   }
 
-  if(mapboxPath === 'mapbox.satellite'){
+  if (mapboxPath === 'mapbox.satellite') {
     const sizeFactor = window.devicePixelRatio >= 1.5 ? '@2x' : '';
     return `https://api.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}${sizeFactor}.webp?access_token=${token}`;
-
   }
   return `https://{a-d}.tiles.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}.vector.pbf?access_token=${token}`;
 }
-

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -82,7 +82,6 @@ export function normalizeSourceUrl(url, token, tokenParam, styleUrl) {
     return `https://api.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}${sizeFactor}.webp?access_token=${token}`;
 
   }
-
-  return `https://api.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}.vector.pbf?access_token=${token}`;
+  return `https://{a-d}.tiles.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}.vector.pbf?access_token=${token}`;
 }
 

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -78,7 +78,8 @@ export function normalizeSourceUrl(url, token, tokenParam, styleUrl) {
   }
 
   if(mapboxPath === 'mapbox.satellite'){
-    return `https://api.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}@2x.webp?access_token=${token}`;
+    const sizeFactor = window.devicePixelRatio >= 1.5 ? '@2x' : '';
+    return `https://api.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}${sizeFactor}.webp?access_token=${token}`;
 
   }
 

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -76,5 +76,12 @@ export function normalizeSourceUrl(url, token, tokenParam, styleUrl) {
     urlObject.searchParams.set(tokenParam, token);
     return decodeURI(urlObject.href);
   }
-  return `https://{a-d}.tiles.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}.vector.pbf?access_token=${token}`;
+
+  if(mapboxPath === 'mapbox.satellite'){
+    return `https://api.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}@2x.webp?access_token=${token}`;
+
+  }
+
+  return `https://api.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}.vector.pbf?access_token=${token}`;
 }
+

--- a/src/util.js
+++ b/src/util.js
@@ -117,7 +117,7 @@ export function getTileJson(glSource, styleUrl, options = {}) {
         promise = Promise.resolve(
           Object.assign({}, glSource, {
             url: undefined,
-            tiles: normalizedSourceUrl,
+            tiles: [normalizedSourceUrl],
           })
         );
       } else {

--- a/src/util.js
+++ b/src/util.js
@@ -117,7 +117,10 @@ export function getTileJson(glSource, styleUrl, options = {}) {
         promise = Promise.resolve(
           Object.assign({}, glSource, {
             url: undefined,
-            tiles: glSource.type === 'raster' ? [normalizedSourceUrl] : normalizedSourceUrl,
+            tiles:
+              glSource.type === 'raster'
+                ? [normalizedSourceUrl]
+                : normalizedSourceUrl,
           })
         );
       } else {

--- a/src/util.js
+++ b/src/util.js
@@ -117,7 +117,7 @@ export function getTileJson(glSource, styleUrl, options = {}) {
         promise = Promise.resolve(
           Object.assign({}, glSource, {
             url: undefined,
-            tiles: [normalizedSourceUrl],
+            tiles: glSource.type === 'raster' ? [normalizedSourceUrl] : normalizedSourceUrl,
           })
         );
       } else {


### PR DESCRIPTION
An issue occurs when trying to add a mapbox style with satellite. 
A lot of request are done to localhost/a, localhost/b, .... 

Also when the style includes a v8 of streets the tiles are not loaded. I compared how mapbox reads the implementation for the tiles and it just perform a call to api.mapbox.com instead of tiles.mapbox.com