### PR TITLE
Add support for raster-dem sources with hillshade layers

### DIFF
--- a/src/shaders.js
+++ b/src/shaders.js
@@ -1,0 +1,119 @@
+/**
+ * Generates a shaded relief image given elevation data.  Uses a 3x3
+ * neighborhood for determining slope and aspect.
+ * @param {Array<ImageData>} inputs Array of input images.
+ * @param {Object} data Data added in the "beforeoperations" event.
+ * @return {ImageData} Output image.
+ */
+export function hillshade(inputs, data) {
+  const elevationImage = inputs[0];
+  const width = elevationImage.width;
+  const height = elevationImage.height;
+  const elevationData = elevationImage.data;
+  const shadeData = new Uint8ClampedArray(elevationData.length);
+  const dp = data.resolution * 2;
+  const maxX = width - 1;
+  const maxY = height - 1;
+  const pixel = [0, 0, 0, 0];
+  const twoPi = 2 * Math.PI;
+  const halfPi = Math.PI / 2;
+  const sunEl = (Math.PI * data.sunEl) / 180;
+  const sunAz = (Math.PI * data.sunAz) / 180;
+  const cosSunEl = Math.cos(sunEl);
+  const sinSunEl = Math.sin(sunEl);
+  let pixelX,
+    pixelY,
+    x0,
+    x1,
+    y0,
+    y1,
+    offset,
+    z0,
+    z1,
+    dzdx,
+    dzdy,
+    slope,
+    aspect,
+    cosIncidence,
+    scaled;
+  function calculateElevation(pixel) {
+    // The method used to extract elevations from the DEM.
+    // In this case the format used is
+    // red + green * 2 + blue * 3
+    //
+    // Other frequently used methods include the Mapbox format
+    // (red * 256 * 256 + green * 256 + blue) * 0.1 - 10000
+    // and the Terrarium format
+    // (red * 256 + green + blue / 256) - 32768
+    //
+    return (pixel[0] * 256 * 256 + pixel[1] * 256 + pixel[2]) * 0.1 - 10000;
+  }
+  for (pixelY = 0; pixelY <= maxY; ++pixelY) {
+    y0 = pixelY === 0 ? 0 : pixelY - 1;
+    y1 = pixelY === maxY ? maxY : pixelY + 1;
+    for (pixelX = 0; pixelX <= maxX; ++pixelX) {
+      x0 = pixelX === 0 ? 0 : pixelX - 1;
+      x1 = pixelX === maxX ? maxX : pixelX + 1;
+
+      // determine elevation for (x0, pixelY)
+      offset = (pixelY * width + x0) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z0 = data.vert * calculateElevation(pixel);
+
+      // determine elevation for (x1, pixelY)
+      offset = (pixelY * width + x1) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z1 = data.vert * calculateElevation(pixel);
+
+      dzdx = (z1 - z0) / dp;
+
+      // determine elevation for (pixelX, y0)
+      offset = (y0 * width + pixelX) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z0 = data.vert * calculateElevation(pixel);
+
+      // determine elevation for (pixelX, y1)
+      offset = (y1 * width + pixelX) * 4;
+      pixel[0] = elevationData[offset];
+      pixel[1] = elevationData[offset + 1];
+      pixel[2] = elevationData[offset + 2];
+      pixel[3] = elevationData[offset + 3];
+      z1 = data.vert * calculateElevation(pixel);
+
+      dzdy = (z1 - z0) / dp;
+
+      slope = Math.atan(Math.sqrt(dzdx * dzdx + dzdy * dzdy));
+
+      aspect = Math.atan2(dzdy, -dzdx);
+      if (aspect < 0) {
+        aspect = halfPi - aspect;
+      } else if (aspect > halfPi) {
+        aspect = twoPi - aspect + halfPi;
+      } else {
+        aspect = halfPi - aspect;
+      }
+
+      cosIncidence =
+        sinSunEl * Math.cos(slope) +
+        cosSunEl * Math.sin(slope) * Math.cos(sunAz - aspect);
+
+      offset = (pixelY * width + pixelX) * 4;
+      scaled = 255 * cosIncidence;
+      shadeData[offset] = scaled;
+      shadeData[offset + 1] = scaled;
+      shadeData[offset + 2] = scaled;
+      shadeData[offset + 3] = elevationData[offset + 3] * data.opacity;
+    }
+  }
+
+  return new ImageData(shadeData, width, height);
+}

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -2,6 +2,7 @@ import Feature from 'ol/Feature.js';
 import LayerGroup from 'ol/layer/Group.js';
 import Map from 'ol/Map.js';
 import Point from 'ol/geom/Point.js';
+import RasterSource from 'ol/source/Raster.js';
 import TileSource from 'ol/source/Tile.js';
 import VectorLayer from 'ol/layer/Vector.js';
 import VectorSource from 'ol/source/Vector.js';
@@ -135,6 +136,22 @@ describe('ol-mapbox-style', function () {
         osm.setOpacity(0.5);
         osm.dispatchEvent({type: 'prerender', frameState: {viewState: {}}});
         should(osm.getOpacity()).eql(0.5);
+      });
+    });
+
+    describe('raster-dem sources', function () {
+      let map;
+      this.beforeEach(function (done) {
+        apply(target, './fixtures/raster-dem.json').then((olMap) => {
+          map = olMap;
+          done();
+        });
+      });
+
+      it('handles raster-dem sources', function () {
+        const rasterDem = map.getLayers().item(0);
+        should(rasterDem.get('mapbox-layers')).eql(['hillshading']);
+        should(rasterDem.getSource()).be.instanceof(RasterSource);
       });
     });
 

--- a/test/fixtures/raster-dem.json
+++ b/test/fixtures/raster-dem.json
@@ -1,0 +1,25 @@
+{
+  "version": 8,
+  "name": "raster-dem",
+  "center": [-98.78906130124426, 37.92686191312036],
+  "zoom": 4,
+  "sources": {
+    "dem": {
+      "type": "raster-dem",
+      "tiles": [
+        "{z}/{x}/{y}.png"
+      ]
+    }
+  },
+  "layers": [
+    {
+      "id": "hillshading",
+      "type": "hillshade",
+      "source": "dem",
+      "paint": {
+        "hillshade-exaggeration": 0.5,
+        "hillshade-light-direction": 45
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds basic support for `raster-dem` sources with layers of type `hillshade`. The supported layer properties are

* `hillshade-exaggeration`
* `hillshade-illumination-direction`

Fixes #714.