### PR TITLE
Limit minzoom for geojson layers

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -1046,6 +1046,10 @@ function finalizeLayer(
             layer.setMinResolution(defaultResolutions[maxZoom] + 1e-9);
           }
         }
+      } else {
+        if (minZoom > 0) {
+          layer.setMaxResolution(defaultResolutions[minZoom] + 1e-9);
+        }
       }
       if (
         source instanceof VectorSource ||

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -371,6 +371,18 @@ describe('ol-mapbox-style', function () {
           });
       });
 
+      it('limits layer minzoom for geojson sources', function (done) {
+        apply(target, './fixtures/geojson-wfs.json')
+          .then(function (map) {
+            const layer = map.getAllLayers()[0];
+            should(layer.getMaxResolution()).eql(defaultResolutions[5] + 1e-9);
+            done();
+          })
+          .catch(function (err) {
+            done(err);
+          });
+      });
+
       it('handles visibility', function (done) {
         apply(target, context)
           .then(function (map) {

--- a/test/fixtures/geojson-wfs.json
+++ b/test/fixtures/geojson-wfs.json
@@ -25,7 +25,8 @@
         "paint": {
           "fill-color": "#020E5D",
           "fill-opacity": 0.8
-        }
+        },
+        "minzoom": 5
       },
       {
         "id": "water_areas_line",
@@ -33,7 +34,8 @@
         "source": "water_areas",
         "paint": {
           "fill-color": "white"
-        }
+        },
+        "minzoom": 6
       }
     ]
   }


### PR DESCRIPTION
This pull request applies the minimum of all layer minzooms for geojson layers to the OpenLayers layer.

This avoids excessive data downloads from geojson sources that have `{bbox-epsg-3857}` in the url.