### PR TITLE
bugfix: pending requests metadata

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -53,7 +53,10 @@ const pendingRequests = {};
  */
 export function fetchResource(resourceType, url, options = {}, metadata) {
   if (url in pendingRequests) {
-    return pendingRequests[url];
+    if (metadata) {
+      metadata.request = pendingRequests[url][0];
+    }
+    return pendingRequests[url][1];
   }
   const request = options.transformRequest
     ? options.transformRequest(url, resourceType) || new Request(url)
@@ -75,7 +78,7 @@ export function fetchResource(resourceType, url, options = {}, metadata) {
       delete pendingRequests[url];
       return Promise.reject(new Error('Error fetching source ' + url));
     });
-  pendingRequests[url] = pendingRequest;
+  pendingRequests[url] = [request, pendingRequest];
   return pendingRequest;
 }
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -15,6 +15,37 @@ describe('util', function () {
         done();
       });
     });
+    it('adds the request to the metadata for both pending and new requests', function (done) {
+      const metadataNotPending = {};
+      const metadataPending = {};
+      fetchResource(
+        'Sprite',
+        'my://resource',
+        {
+          transformRequest: function (url, resourceType) {
+            should(url).equal('my://resource');
+            should(resourceType).equal('Sprite');
+            return new Request('/fixtures/sprites.json');
+          },
+        },
+        metadataNotPending
+      );
+      fetchResource(
+        'Sprite',
+        'my://resource',
+        {
+          transformRequest: function (url, resourceType) {
+            should(url).equal('my://resource');
+            should(resourceType).equal('Sprite');
+            return new Request('/fixtures/sprites.json');
+          },
+        },
+        metadataPending
+      );
+      should('request' in metadataPending).true();
+      should(metadataPending.request).equal(metadataNotPending.request);
+      done();
+    });
   });
   describe('getTileJson', function () {
     it('resolves mapbox:// tile urls properly', function (done) {


### PR DESCRIPTION
fetchResource() caches pending requests (or rather the Promises of their
responses) to prevent repeated calls for the same resource. If a
response is not pending then the generated Request object may be
returned via the metadata parameter, but before this commit then if the
response was already pending the Request object was never returned in
this way. This led to problems in getTileJson() where it is expected
(required) that the request has been set.

With this PR then not just the Promises of the responses but also the
original Request objects are cached so that the request parameter can
also be set in the metadata object when a pending response is returned.

The problem was noticed while trying to use apply() in parallel on two
group layers using each a different style URL, which however both
used the same tileset as source.