### PR TITLE
Add support for labels with symbol-spacing

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1263,6 +1263,18 @@ export function stylefunction(
                   featureState
                 );
           text.setPlacement(placement);
+          if (typeof text.setRepeat === 'function') {
+            const symbolSpacing = getValue(
+              layer,
+              'layout',
+              'symbol-spacing',
+              zoom,
+              f,
+              functionCache,
+              featureState
+            );
+            text.setRepeat(symbolSpacing * 2);
+          }
           text.setOverflow(placement === 'point');
           let textHaloWidth = getValue(
             layer,


### PR DESCRIPTION
When an OpenLayers version that contains https://github.com/openlayers/openlayers/pull/14400 is used, labels will now be repeated on long line segments according to the `symbol-spacing` layout property.