### PR TITLE
Support projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Renames and re-exports [apply](#apply)
 
 #### apply
 
-▸ **apply**(`mapOrGroup`, `style`, `options?`): `Promise`&lt;`Map` \| `LayerGroup`>
+▸ **apply**(`mapOrGroupOrElement`, `style`, `options?`): `Promise`&lt;`Map` \| `LayerGroup`>
 
 Loads and applies a Mapbox Style object into an OpenLayers Map or LayerGroup.
 This includes the map background, the layers, and for Map instances that did not
@@ -164,11 +164,11 @@ Map or LayerGroup instance, which holds the Mapbox Style object.
 
 ##### Parameters
 
-| Name         | Type                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| :----------- | :------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mapOrGroup` | `string` \| `HTMLElement` \| `Map` \| `LayerGroup` | Either an existing OpenLayers Map instance, or a HTML element, or the id of a HTML element that will be the target of a new OpenLayers Map, or a layer group. If layer group, styles releated to the map and view will be ignored.                                                                                                                                                                                                                                                                                                                                    |
-| `style`      | `any`                                              | JSON style object or style url pointing to a Mapbox Style object. When using Mapbox APIs, the url is the `styleUrl` shown in Mapbox Studio's "share" panel. In addition, the `accessToken` option (see below) must be set. When passed as JSON style object, all OpenLayers layers created by `apply()` will be immediately available, but they may not have a source yet (i.e. when they are defined by a TileJSON url in the Mapbox Style document). When passed as style url, layers will be added to the map when the Mapbox Style document is loaded and parsed. |
-| `options`    | [`Options`](#interfacesinternal_optionsmd)         | Options.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| Name                  | Type                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| :-------------------- | :------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mapOrGroupOrElement` | `string` \| `HTMLElement` \| `Map` \| `LayerGroup` | Either an existing OpenLayers Map instance, or a HTML element, or the id of a HTML element that will be the target of a new OpenLayers Map, or a layer group. If layer group, styles releated to the map and view will be ignored.                                                                                                                                                                                                                                                                                                                                    |
+| `style`               | `any`                                              | JSON style object or style url pointing to a Mapbox Style object. When using Mapbox APIs, the url is the `styleUrl` shown in Mapbox Studio's "share" panel. In addition, the `accessToken` option (see below) must be set. When passed as JSON style object, all OpenLayers layers created by `apply()` will be immediately available, but they may not have a source yet (i.e. when they are defined by a TileJSON url in the Mapbox Style document). When passed as style url, layers will be added to the map when the Mapbox Style document is loaded and parsed. |
+| `options`             | [`Options`](#interfacesinternal_optionsmd)         | Options.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
 ##### Returns
 
@@ -552,6 +552,7 @@ The source id.
 - [accessToken](#accessToken)
 - [accessTokenParam](#accessTokenParam)
 - [getImage](#getImage)
+- [projection](#projection)
 - [resolutions](#resolutions)
 - [styleUrl](#styleUrl)
 - [transformRequest](#transformRequest)
@@ -599,12 +600,23 @@ This function be used for icons not in the sprite or to override sprite icons.
 
 * * *
 
+#### projection
+
+• **projection**: `string`
+
+Only useful when working with non-standard projections.
+Code of a projection registered with OpenLayers. All sources of the style must be provided in this
+projection. The projection must also have a valid extent defined, which will be used to determine the
+origin and resolutions of the tile grid for all tiled sources of the style.
+
+* * *
+
 #### resolutions
 
 • **resolutions**: `number`\[]
 
-Resolutions for mapping resolution to zoom level.
-Only needed when working with non-standard tile grids or projections.
+Only useful when working with non-standard projections.
+Resolutions for mapping resolution to the `zoom` used in the Mapbox style.
 
 * * *
 

--- a/examples/esri-4326.js
+++ b/examples/esri-4326.js
@@ -1,0 +1,10 @@
+import 'ol/ol.css';
+import {apply} from 'ol-mapbox-style';
+
+apply(
+  'map',
+  'https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_GCS_v2/VectorTileServer/resources/styles/',
+  {
+    projection: 'EPSG:4326',
+  }
+);

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,6 +24,7 @@
     <li><a href="wms.html">OSM with WMS overlay</a> &ndash; Map with two raster layers (OSM base map and WMS overlay)</li>
     <li><a href="tilejson.html">TileJSON</a> &ndash; Map with a raster layer from a TileJSON definition</li>
     <li><a href="tilejson-vectortile.html">TileJSON vector tiles</a> &ndash; Vector tile map with a source from a TileJSON definition</li>
+    <li><a href="esri-4326.html">Esri vector tiles 4326</a> &ndash; MapTiler with custom <code>projection</code></li>
     <li><a href="esri-transformrequest.html">Esri vector tiles with bad tile URLs</a> &ndash; Esri vector tile map using the <code>transformRequest</code> option to fix tile urls.</li>
     <li><a href="openmaptiles-layer.html">OpenMapTiles Layer</a> (requires a <a href="https://cloud.maptiler.com/account/keys">Maptiler Cloud API token</a>) &ndash; Vector tile layer from OpenMapTiles's basic style</li>
     <li><a href="geojson-layer.html">GeoJSON Layer</a> &ndash; Vector layer from GeoJSON</li>


### PR DESCRIPTION
This pull request adds support for projections, using the new `projection` option. It requires the used projection to be set up properly in OpenLayers. The projection extent determines the tile grid origin and resolutions for all layer sources.

To make configuration easier, projections with units other than meters now also work out of the box, because the style resolutions will be adjusted for the different units.