### PR TITLE
Make applyStyle respect existing VectorLayer source

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -298,7 +298,13 @@ export function applyStyle(
           }
           const glSource = glStyle.sources[sourceId];
           let source = layer.getSource();
-          if (!source || source.get('mapbox-source') !== glSource) {
+          if (
+            !source ||
+            (
+              source.get('mapbox-source') &&
+              source.get('mapbox-source') !== glSource
+            )
+          ) {
             source = setupGeoJSONSource(glSource, styleUrl, options);
           }
           const targetSource = /** @type {VectorSource} */ (layer.getSource());


### PR DESCRIPTION
This fix makes applyStyle respect a pre-existing source on VectorLayer. As `applyStyle` docs claim, it shall not override a source if it is already set, but the check for equality on `mapbox-source` property triggers a source update if the source set was not created from the mapbox style specification itself.