### PR TITLE
Fix 'mapbox-layers' metadata for raster layers

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -874,6 +874,7 @@ function processStyle(glStyle, mapOrGroup, styleUrl, options) {
         } else if (glSource.type == 'vector') {
           layer = setupVectorLayer(glSource, styleUrl, options);
         } else if (glSource.type == 'raster') {
+          layerIds = [];
           layer = setupRasterLayer(glSource, styleUrl, options);
           layer.setVisible(
             glLayer.layout ? glLayer.layout.visibility !== 'none' : true
@@ -888,6 +889,7 @@ function processStyle(glStyle, mapOrGroup, styleUrl, options) {
           glSource.type == 'raster-dem' &&
           glLayer.type == 'hillshade'
         ) {
+          layerIds = [];
           const hillshadeLayer = setupHillshadeLayer(
             glSource,
             styleUrl,


### PR DESCRIPTION
Currently, when a raster source is used more than once in a map, the `mapbox-layers` metadata field will incorrectly list all the layers that use the source, instead of just the one that is actually represented by the OpenLayers layer.

This pull request fixes that, i.e. for raster layers, `mapbox-layers` will always only contain a single entry.