### PR TITLE
Remove SRS identifier from geojson BBOX template replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Next version
 
+### Breaking changes
+
+#### BBOX templates for `geojson` souurces
+
+Previously, the `{bbox-epsg-3857}` and `{bbox-epsg-[custom projection srs code]}` template replacement included the projection's SRS identifier, e.g. `1234,4567,4321,7654,EPSG:9876`. Now, the template replacement just includes the bounding box. This means that e.g. WFS source URLs need to be changed in the Mapbox style.
+
+If you previously had a source definition like
+```json
+{
+  "type": "geojson",
+  "data": "https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=osm:water_areas&outputFormat=application/json&srsname=EPSG:4326&bbox={bbox-epsg-3857}"
+}
+```
+
+you have to change it to
+
+```json
+{
+  "type": "geojson",
+  "data": "https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=osm:water_areas&outputFormat=application/json&srsname=EPSG:4326&bbox={bbox-epsg-3857},EPSG:3857"
+}
+```
+The reason for this breaking change is compatibility with OCG API Features and other services that do not accept the SRS identifier as additional BBOX parameter.
+
 ## 9.7.0
 
 * Improved icon halo - now looks the same as text halo

--- a/examples/data/geojson-wfs.json
+++ b/examples/data/geojson-wfs.json
@@ -7,7 +7,7 @@
     "sources": {
       "water_areas": {
         "type": "geojson",
-        "data": "https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=osm:water_areas&outputFormat=application/json&srsname=EPSG:4326&bbox={bbox-epsg-3857}"
+        "data": "https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=osm:water_areas&outputFormat=application/json&srsname=EPSG:4326&bbox={bbox-epsg-3857},EPSG:3857"
       },
       "osm": {
         "type": "raster",

--- a/src/apply.js
+++ b/src/apply.js
@@ -735,10 +735,7 @@ function setupGeoJSONSource(glSource, styleUrl, options) {
     if (/\{bbox-[0-9a-z-]+\}/.test(geoJsonUrl)) {
       const extentUrl = (extent, resolution, projection) => {
         const bboxTemplate = getBboxTemplate(projection);
-        return geoJsonUrl.replace(
-          bboxTemplate,
-          `${extent.join(',')},${projection.getCode()}`
-        );
+        return geoJsonUrl.replace(bboxTemplate, `${extent.join(',')}`);
       };
       const source = new VectorSource({
         attributions: glSource.attribution,

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -198,11 +198,9 @@ describe('ol-mapbox-style', function () {
               .getUrl()
               .call(this, map.getView().calculateExtent(), 1, get('EPSG:3857'))
           );
-          const bbox = url.searchParams.get('bbox').split(',');
-          const proj = bbox.pop();
+          const bbox = url.searchParams.get('bbox');
           const extent = map.getView().calculateExtent();
-          should(proj).be.eql('EPSG:3857');
-          should(bbox.join(',') === extent.join(',')).be.true();
+          should(bbox).be.equal(extent.join(','));
           should(source).be.instanceof(VectorSource);
           should(layer.getStyle()).be.a.Function();
           done();
@@ -234,11 +232,9 @@ describe('ol-mapbox-style', function () {
                     map.getView().getProjection()
                   )
               );
-              const bbox = url.searchParams.get('bbox').split(',');
-              const proj = bbox.pop();
+              const bbox = url.searchParams.get('bbox');
               const extent = map.getView().calculateExtent();
-              should(proj).be.eql('EPSG:4326');
-              should(bbox.join(',') === extent.join(',')).be.true();
+              should(bbox).be.equal(extent.join(','));
               done();
             })
             .catch(done);


### PR DESCRIPTION
Previously, the `{bbox-epsg-3857}` and `{bbox-epsg-[custom projection srs code]}` template replacement included the projection's SRS identifier, e.g. `1234,4567,4321,7654,EPSG:9876`. Now, the template replacement just includes the bounding box. This means that e.g. WFS source URLs need to be changed in the Mapbox style.

If you previously had a source definition like
```json
{
  "type": "geojson",
  "data": "https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=osm:water_areas&outputFormat=application/json&srsname=EPSG:4326&bbox={bbox-epsg-3857}"
}
```

you have to change it to

```json
{
  "type": "geojson",
  "data": "https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=osm:water_areas&outputFormat=application/json&srsname=EPSG:4326&bbox={bbox-epsg-3857},EPSG:3857"
}
```
The reason for this breaking change is compatibility with OCG API Features and other services that do not accept the SRS identifier as additional BBOX parameter.