### PR TITLE
add `removeMapboxLayer` to exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,4 +16,5 @@ export {
   getMapboxLayer,
   updateMapboxLayer,
   addMapboxLayer,
+  removeMapboxLayer,
 } from './apply.js';


### PR DESCRIPTION
This adds the missing export `removeMapboxLayer` to the exports of index.js