### PR TITLE
Fix updateMapboxLayer by fixing function and filter cache management

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -20,6 +20,7 @@ import mb2css from 'mapbox-to-css-font';
 import spec from '@mapbox/mapbox-gl-style-spec/reference/v8.json';
 import {applyLetterSpacing, wrapText} from './text.js';
 import {
+  clearFunctionCache,
   createCanvas,
   defaultResolutions,
   deg2rad,
@@ -201,7 +202,10 @@ let renderTransparentEnabled = false;
  * Default is `false`.
  */
 export function renderTransparent(enabled) {
-  renderTransparentEnabled = enabled;
+  if (enabled !== renderTransparentEnabled) {
+    clearFunctionCache();
+    renderTransparentEnabled = enabled;
+  }
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -13,9 +13,18 @@ export function getFunctionCache(glStyle) {
   if (!glStyle.id) {
     glStyle.id = styleId++;
   }
-  const functionCache = {};
-  functionCacheByStyleId[glStyle.id] = functionCache;
+  let functionCache = functionCacheByStyleId[glStyle.id];
+  if (!functionCache) {
+    functionCache = {};
+    functionCacheByStyleId[glStyle.id] = functionCache;
+  }
   return functionCache;
+}
+
+export function clearFunctionCache() {
+  for (const key in functionCacheByStyleId) {
+    delete functionCacheByStyleId[key];
+  }
 }
 
 /**
@@ -26,8 +35,11 @@ export function getFilterCache(glStyle) {
   if (!glStyle.id) {
     glStyle.id = styleId++;
   }
-  const filterCache = {};
-  filterCacheByStyleId[glStyle.id] = filterCache;
+  let filterCache = filterCacheByStyleId[glStyle.id];
+  if (!filterCache) {
+    filterCache = {};
+    filterCacheByStyleId[glStyle.id] = filterCache;
+  }
   return filterCache;
 }
 

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -1053,8 +1053,12 @@ describe('ol-mapbox-style', function () {
             layer: 'landuse',
             class: 'park',
           });
-          const styles = getStyle(feature, 1);
+          let styles = getStyle(feature, 1);
           should(styles[0].getFill().getColor()).eql('rgba(255,0,0,1)');
+          layer.paint['fill-color'] = 'blue';
+          updateMapboxLayer(map, layer);
+          styles = getStyle(feature, 1);
+          should(styles[0].getFill().getColor()).eql('rgba(0,0,255,1)');
           done();
         })
         .catch(function (error) {


### PR DESCRIPTION
`updateMapboxLayer()` did not work as expected, because the function and filter caches were never cleared. Now that they are, a flaw with `renderTransparent()` was revealed, which is also fixed with this pull request.