### PR TITLE
Ensure sources have a unique key

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -267,6 +267,13 @@ export function applyStyle(
                 layer.setSource(source);
               } else if (source !== targetSource) {
                 targetSource.setTileUrlFunction(source.getTileUrlFunction());
+                if (
+                  typeof targetSource.setUrls === 'function' &&
+                  typeof source.getUrls === 'function'
+                ) {
+                  // to get correct keys for tile cache and queue
+                  targetSource.setUrls(source.getUrls());
+                }
                 //@ts-ignore
                 if (!targetSource.format_) {
                   //@ts-ignore


### PR DESCRIPTION
This fixes a potential problem with the OpenLayers tile queue (and cache): currently, Vector Tile Sources created from TileJSON by ol-mapbox-style do not have a source key, because they do not have a url set.