### PR TITLE
Set projection from projection option as GeoJSON dataProjection

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -704,7 +704,6 @@ function setupHillshadeLayer(glSource, styleUrl, options) {
   return layer;
 }
 
-const geoJsonFormat = new GeoJSON();
 /**
  * @param {Object} glSource glStyle source.
  * @param {string} styleUrl Style URL.
@@ -712,6 +711,9 @@ const geoJsonFormat = new GeoJSON();
  * @return {VectorSource} Configured vector source.
  */
 function setupGeoJSONSource(glSource, styleUrl, options) {
+  const geoJsonFormat = options.projection
+    ? new GeoJSON({dataProjection: options.projection})
+    : new GeoJSON();
   const data = glSource.data;
   const sourceOptions = {};
   if (typeof data == 'string') {


### PR DESCRIPTION
Currently, when using the `projection` option, vector data would be transformed from EPSG:4326, instead of leaving the coordinates untouched, because the GeoJSON format is not configured with the provided `projection` as its `dataProjection`. This pull request fixes that.