### PR TITLE
Add getStyleForLayer() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ and open a browser on the host and port indicated in the console output (usually
 - [getLayers](#getLayers)
 - [getMapboxLayer](#getMapboxLayer)
 - [getSource](#getSource)
+- [getStyleForLayer](#getStyleForLayer)
 - [recordStyleLayer](#recordStyleLayer)
 - [removeMapboxLayer](#removeMapboxLayer)
 - [renderTransparent](#renderTransparent)
@@ -418,6 +419,29 @@ Get the OpenLayers source instance for the provided Mapbox Style `source`.
 `Source`
 
 OpenLayers source instance.
+
+* * *
+
+#### getStyleForLayer
+
+▸ **getStyleForLayer**(`feature`, `resolution`, `olLayer`, `layerId`): `Style`\[]
+
+Get the the style for a specific Mapbox layer only. This can be useful for creating a legend.
+
+##### Parameters
+
+| Name         | Type                                         | Description                                 |
+| :----------- | :------------------------------------------- | :------------------------------------------ |
+| `feature`    | `RenderFeature` \| `Feature`&lt;`Geometry`>  | OpenLayers feature.                         |
+| `resolution` | `number`                                     | View resolution.                            |
+| `olLayer`    | `VectorLayer`&lt;`any`> \| `VectorTileLayer` | OpenLayers layer.                           |
+| `layerId`    | `string`                                     | Id of the Mapbox layer to get the style for |
+
+##### Returns
+
+`Style`\[]
+
+Styles for the provided Mapbox layer.
 
 * * *
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ export {
   stylefunction,
   recordStyleLayer,
   renderTransparent,
+  getStyleForLayer,
 } from './stylefunction.js';
 export {apply as default, apply, applyBackground, applyStyle} from './apply.js';
 export {

--- a/test/stylefunction.test.js
+++ b/test/stylefunction.test.js
@@ -8,6 +8,7 @@ import {
   apply,
   stylefunction as applyStyleFunction,
   getFeatureState,
+  getStyleForLayer,
   recordStyleLayer,
   renderTransparent,
   setFeatureState,
@@ -859,6 +860,85 @@ describe('stylefunction', function () {
           const styles2 = styleFunction2(feature2, 1);
           const fill2 = styles2[0].getFill();
           should(fill2.getColor()).eql('rgba(178,223,138,1)');
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    });
+  });
+
+  describe('getStyleForLayer()', function () {
+    // create a mapbox style with a geojson source and two layers
+    const style = {
+      version: '8',
+      name: 'test',
+      sources: {
+        'geojson': {
+          type: 'geojson',
+          data: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: [
+                    [
+                      [-1, -1],
+                      [-1, 1],
+                      [1, 1],
+                      [1, -1],
+                      [-1, -1],
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      layers: [
+        {
+          id: 'test1',
+          type: 'fill',
+          source: 'geojson',
+          paint: {
+            'fill-color': '#A6CEE3',
+          },
+        },
+        {
+          id: 'test2',
+          type: 'fill',
+          source: 'geojson',
+          paint: {
+            'fill-color': '#B2DF8A',
+          },
+        },
+      ],
+    };
+
+    it('returns the style for a layer', function (done) {
+      apply(document.createElement('div'), style)
+        .then(function (map) {
+          const layer = map.getLayers().item(0);
+          // use the getStyleForLayer function to get the styles array for the first layer
+          // getStyleForLayer takes 4 arguments
+          const [style1] = getStyleForLayer(
+            layer.getSource().getFeatures()[0],
+            1,
+            layer,
+            'test1'
+          );
+          should(style1.getFill().getColor()).eql('rgba(166,206,227,1)');
+          // same as above fo the 2nd layer
+          const [style2] = getStyleForLayer(
+            layer.getSource().getFeatures()[0],
+            1,
+            layer,
+            'test2'
+          );
+          should(style2.getFill().getColor()).eql('rgba(178,223,138,1)');
           done();
         })
         .catch(function (err) {


### PR DESCRIPTION
This pull request adds a function that can help existing applications to live without `recordStyleLayer(true)`, and to create legends more easily.

The function calls the layer's style function internally, but only evaluates the style for a single Mapbox layer.