### PR TITLE
Fix @mapbox/mapbox-gl-style-spec version to 13.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.6.0",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+        "@mapbox/mapbox-gl-style-spec": "13.17.1",
         "mapbox-to-css-font": "^2.4.1",
         "ol": "^7.3.0"
       },
@@ -716,24 +716,24 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.28.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
-      "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
+      "version": "13.17.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.17.1.tgz",
+      "integrity": "sha512-8Z+53JP3TAUC2FihyCDNEiOkfSNnQH/iZ7Jkm02xRKdWeTWAKtmsyCcPn2HKXkundiaYvaZsbEd4AwvX3+MsrQ==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/unitbezier": "^0.0.0",
         "csscolorparser": "~1.0.2",
         "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.5",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
       },
       "bin": {
-        "gl-style-composite": "bin/gl-style-composite.js",
-        "gl-style-format": "bin/gl-style-format.js",
-        "gl-style-migrate": "bin/gl-style-migrate.js",
-        "gl-style-validate": "bin/gl-style-validate.js"
+        "gl-style-composite": "bin/gl-style-composite",
+        "gl-style-format": "bin/gl-style-format",
+        "gl-style-migrate": "bin/gl-style-migrate",
+        "gl-style-validate": "bin/gl-style-validate"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -8206,6 +8206,27 @@
         "mapbox-to-css-font": "^2.4.1"
       }
     },
+    "node_modules/ol-mapbox-style/node_modules/@mapbox/mapbox-gl-style-spec": {
+      "version": "13.28.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
+      "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "minimist": "^1.2.6",
+        "rw": "^1.3.3",
+        "sort-object": "^0.3.2"
+      },
+      "bin": {
+        "gl-style-composite": "bin/gl-style-composite.js",
+        "gl-style-format": "bin/gl-style-format.js",
+        "gl-style-migrate": "bin/gl-style-migrate.js",
+        "gl-style-validate": "bin/gl-style-validate.js"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -12602,16 +12623,16 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.28.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
-      "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
+      "version": "13.17.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.17.1.tgz",
+      "integrity": "sha512-8Z+53JP3TAUC2FihyCDNEiOkfSNnQH/iZ7Jkm02xRKdWeTWAKtmsyCcPn2HKXkundiaYvaZsbEd4AwvX3+MsrQ==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
         "@mapbox/unitbezier": "^0.0.0",
         "csscolorparser": "~1.0.2",
         "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.5",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
       }
@@ -18285,6 +18306,23 @@
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1"
+      },
+      "dependencies": {
+        "@mapbox/mapbox-gl-style-spec": {
+          "version": "13.28.0",
+          "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
+          "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
+          "requires": {
+            "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+            "@mapbox/point-geometry": "^0.1.0",
+            "@mapbox/unitbezier": "^0.0.0",
+            "csscolorparser": "~1.0.2",
+            "json-stringify-pretty-compact": "^2.0.0",
+            "minimist": "^1.2.6",
+            "rw": "^1.3.3",
+            "sort-object": "^0.3.2"
+          }
+        }
       }
     },
     "on-finished": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "npm run karma -- --single-run --log-level error"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+    "@mapbox/mapbox-gl-style-spec": "13.17.1",
     "mapbox-to-css-font": "^2.4.1",
     "ol": "^7.3.0"
   },


### PR DESCRIPTION
There is a possible legal problem with `ol-mapbox-style` as it depends on `@mapbox/mapbox-gl-style-spec` `^13.23.1`. The source code of this package is actually part of the `mapbox-gl-js` repo (https://github.com/mapbox/mapbox-gl-js/tree/main/src/style-spec). The code in this repo is now restricted to be used only with mapbox services.
It is possible that this makes `ol-mapbox-style` legally usable only with mapbox services. (And possibly also the whole `ol` ?)

This PR changes the dependency to the latest version before the license change (`v13.17.1`).

Alternatively, `@maplibre/maplibre-gl-style-spec` `v14.0.2` could be used (https://github.com/maplibre/maplibre-style-spec/blob/main/CHANGELOG.md#1402) but that would require more changes in the code and I'm not sure it's actually 100 % compatible.

Also, there is an issue with circular dependency: `ol-mapbox-style@main` -> `ol@^7.3.0` -> `ol-mapbox-style@^9.2.0` -> `@mapbox/mapbox-gl-style-spec@^13.23.1`.
So this PR ensures that `ol-mapbox-style` does not use any code from the newer version, but it is still installed as a dependency, until the dependency in `ol` is upgraded and `ol` is released and dependency in `ol-mapbox-style` is upgraded 😕 

@ahocevar Any better ideas how to solve the issue?