### PR TITLE
Add support for SDF sprites

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -31,6 +31,7 @@
     <li><a href="geojson-layer.html">GeoJSON Layer</a> &ndash; Vector layer from GeoJSON</li>
     <li><a href="stylefunction.html">Style function</a> &ndash; Low-level API for creating a style function from a Mapbox Style source</li>
     <li><a href="apply-layergroup.html">Apply to a Layer Group</a> &ndash; Apply style to a layer group instead of an entire map</li>
+    <li><a href="sdf-sprites.html">SDF Sprites</a> &ndash; Handle SDF sprites instead of regular image</li>
   </ul>
 </body>
 </html>

--- a/examples/sdf-sprites.js
+++ b/examples/sdf-sprites.js
@@ -1,0 +1,16 @@
+import 'ol/ol.css';
+import olms from 'ol-mapbox-style';
+
+const baseUrl = 'https://api.maptiler.com/maps/test-bright/style.json';
+
+let key = document.cookie.replace(
+  /(?:(?:^|.*;\s*)maptiler_access_token\s*\=\s*([^;]*).*$)|^.*$/,
+  '$1'
+);
+if (!key) {
+  key = window.prompt('Enter your MapTiler API access token:');
+  document.cookie =
+    'maptiler_access_token=' + key + '; expires=Fri, 31 Dec 9999 23:59:59 GMT';
+}
+
+olms('map', baseUrl + '?key=' + key);


### PR DESCRIPTION
This PR adds support for SDF sprites.

Though not very well documented, the mapbox-gl-js has support SDF sprites for years.
Such sprites contain "distances" instead of the regular color information:
![image](https://github.com/openlayers/ol-mapbox-style/assets/707817/45654387-ae31-45ce-a964-43fe6730e36d)
In such cases, the `sprite.json` has a `sdf: true` on each image.

The benefits of the SDF sprites include better scalability and ability to recolor the images nicely.
We would like to start using SDF sprites in MapTiler in the future, but still remain compatible with the `ol+ol-mapbox-style` stack, so this PR adds a basic support for the SDF sprites.

- In case of regular icons, the whole sprite image atlas is "unSDFied" once when it's first needed and then used the regular way (color tinting works the same as before)
- In case of halo, only the specific icon is "unSDFied" with proper coloring and halo color. (Color tinting would also tint the halo, so the color needs to be burned in.)
- SDF sprites are not supported in patterns, the is the case even in the mapbox specification.

There is no performance change for non-SDF sprites at all.