### PR TITLE
Export MapboxVectorLayer with index module

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,21 +120,510 @@ and open a browser on the host and port indicated in the console output (usually
 
 ### Table of contents
 
+#### References
+
+- [default](#default)
+
 #### Modules
 
-- [MapboxVectorLayer](#modulesmapboxvectorlayermd)
-- [index](#modulesindexmd)
+- [&lt;internal\\>](#modulesinternal_md)
 
-<a name="classesmapboxvectorlayerdefaultmd"></a>
+#### Classes
 
-## Class: default
+- [MapboxVectorLayer](#classesmapboxvectorlayermd)
 
-[MapboxVectorLayer](#modulesmapboxvectorlayermd).default
+#### Functions
+
+- [addMapboxLayer](#addMapboxLayer)
+- [apply](#apply)
+- [applyBackground](#applyBackground)
+- [applyStyle](#applyStyle)
+- [getFeatureState](#getFeatureState)
+- [getLayer](#getLayer)
+- [getLayers](#getLayers)
+- [getMapboxLayer](#getMapboxLayer)
+- [getSource](#getSource)
+- [getStyleForLayer](#getStyleForLayer)
+- [recordStyleLayer](#recordStyleLayer)
+- [removeMapboxLayer](#removeMapboxLayer)
+- [renderTransparent](#renderTransparent)
+- [setFeatureState](#setFeatureState)
+- [stylefunction](#stylefunction)
+- [updateMapboxLayer](#updateMapboxLayer)
+
+### References
+
+#### default
+
+Renames and re-exports [apply](#apply)
+
+### Functions
+
+#### addMapboxLayer
+
+▸ **addMapboxLayer**(`mapOrGroup`, `mapboxLayer`, `beforeLayerId?`): `Promise`&lt;`void`>
+
+Add a new Mapbox Layer object to the style. The map will be re-rendered.
+
+##### Parameters
+
+| Name             | Type                  | Description                                                              |
+| :--------------- | :-------------------- | :----------------------------------------------------------------------- |
+| `mapOrGroup`     | `Map` \| `LayerGroup` | The Map or LayerGroup `apply` was called on.                             |
+| `mapboxLayer`    | `any`                 | Mapbox Layer object.                                                     |
+| `beforeLayerId?` | `string`              | Optional id of the Mapbox Layer before the new layer that will be added. |
+
+##### Returns
+
+`Promise`&lt;`void`>
+
+Resolves when the added layer is available.
+
+* * *
+
+#### apply
+
+▸ **apply**(`mapOrGroupOrElement`, `style`, `options?`): `Promise`&lt;`Map` \| `LayerGroup`>
+
+Loads and applies a Mapbox Style object into an OpenLayers Map or LayerGroup.
+This includes the map background, the layers, and for Map instances that did not
+have a View defined yet also the center and the zoom.
+
+**Example:**
+
+```js
+import apply from 'ol-mapbox-style';
+
+apply('map', 'mapbox://styles/mapbox/bright-v9', {accessToken: 'YOUR_MAPBOX_TOKEN'});
+```
+
+The center and zoom will only be set if present in the Mapbox Style document,
+and if not already set on the OpenLayers map.
+
+Layers will be added to the OpenLayers map, without affecting any layers that
+might already be set on the map.
+
+Layers added by `apply()` will have two additional properties:
+
+- `mapbox-source`: The `id` of the Mapbox Style document's source that the
+  OpenLayers layer was created from. Usually `apply()` creates one
+  OpenLayers layer per Mapbox Style source, unless the layer stack has
+  layers from different sources in between.
+- `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
+  included in the OpenLayers layer.
+
+This function sets an additional `mapbox-style` property on the OpenLayers
+Map or LayerGroup instance, which holds the Mapbox Style object.
+
+##### Parameters
+
+| Name                  | Type                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| :-------------------- | :------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mapOrGroupOrElement` | `string` \| `Map` \| `LayerGroup` \| `HTMLElement` | Either an existing OpenLayers Map instance, or a HTML element, or the id of a HTML element that will be the target of a new OpenLayers Map, or a layer group. If layer group, styles releated to the map and view will be ignored.                                                                                                                                                                                                                                                                                                                                    |
+| `style`               | `any`                                              | JSON style object or style url pointing to a Mapbox Style object. When using Mapbox APIs, the url is the `styleUrl` shown in Mapbox Studio's "share" panel. In addition, the `accessToken` option (see below) must be set. When passed as JSON style object, all OpenLayers layers created by `apply()` will be immediately available, but they may not have a source yet (i.e. when they are defined by a TileJSON url in the Mapbox Style document). When passed as style url, layers will be added to the map when the Mapbox Style document is loaded and parsed. |
+| `options`             | [`Options`](#interfacesinternal_optionsmd)         | Options.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+
+##### Returns
+
+`Promise`&lt;`Map` \| `LayerGroup`>
+
+A promise that resolves after all layers have been added to
+the OpenLayers Map instance or LayerGroup, their sources set, and their styles applied. The
+`resolve` callback will be called with the OpenLayers Map instance or LayerGroup as
+argument.
+
+* * *
+
+#### applyBackground
+
+▸ **applyBackground**(`mapOrLayer`, `glStyle`, `options?`): `Promise`&lt;`any`>
+
+Applies properties of the Mapbox Style's first `background` layer to the
+provided map or layer (group).
+
+**Example:**
+
+```js
+import {applyBackground} from 'ol-mapbox-style';
+import {Map} from 'ol';
+
+const map = new Map({target: 'map'});
+applyBackground(map, 'https://api.maptiler.com/maps/basic/style.json?key=YOUR_OPENMAPTILES_TOKEN');
+```
+
+##### Parameters
+
+| Name         | Type                                       | Description                      |
+| :----------- | :----------------------------------------- | :------------------------------- |
+| `mapOrLayer` | `Map` \| `BaseLayer`                       | OpenLayers Map or layer (group). |
+| `glStyle`    | `any`                                      | Mapbox Style object or url.      |
+| `options`    | [`Options`](#interfacesinternal_optionsmd) | Options.                         |
+
+##### Returns
+
+`Promise`&lt;`any`>
+
+Promise that resolves when the background is applied.
+
+* * *
+
+#### applyStyle
+
+▸ **applyStyle**(`layer`, `glStyle`, `sourceOrLayersOrOptions?`, `optionsOrPath?`, `resolutions?`): `Promise`&lt;`any`>
+
+Applies a style function to an `ol/layer/VectorTile` or `ol/layer/Vector`
+with an `ol/source/VectorTile` or an `ol/source/Vector`. If the layer does not have a source
+yet, it will be created and populated from the information in the `glStyle` (unless `updateSource` is
+set to `false`).
+
+**Example:**
+
+```js
+import {applyStyle} from 'ol-mapbox-style';
+import {VectorTile} from 'ol/layer.js';
+
+const layer = new VectorTile({declutter: true});
+applyStyle(layer, 'https://api.maptiler.com/maps/basic/style.json?key=YOUR_OPENMAPTILES_TOKEN');
+```
+
+The style function will render all layers from the `glStyle` object that use the source
+of the first layer, the specified `source`, or a subset of layers from the same source. The
+source needs to be a `"type": "vector"` or `"type": "geojson"` source.
+
+Two additional properties will be set on the provided layer:
+
+- `mapbox-source`: The `id` of the Mapbox Style document's source that the
+  OpenLayers layer was created from. Usually `apply()` creates one
+  OpenLayers layer per Mapbox Style source, unless the layer stack has
+  layers from different sources in between.
+- `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
+  included in the OpenLayers layer.
+
+##### Parameters
+
+| Name                       | Type                                                                                                                                   | Default value | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `layer`                    | `VectorLayer`&lt;`any`> \| `VectorTileLayer`                                                                                           | `undefined`   | OpenLayers layer. When the layer has a source configured, it will be modified to use the configuration from the glStyle's `source`. Options specified on the layer's source will override those from the glStyle's `source`, except for `url` and `tileUrlFunction`. When the source projection is the default (`EPSG:3857`), the `tileGrid` will also be overridden. If you'd rather not have ol-mapbox-style modify the source, configure `applyStyle()` with the `updateSource: false` option. |
+| `glStyle`                  | `any`                                                                                                                                  | `undefined`   | Mapbox Style object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `sourceOrLayersOrOptions?` | `string` \| `string`\[] \| [`Options`](#interfacesinternal_optionsmd) & [`ApplyStyleOptions`](#interfacesinternal_applystyleoptionsmd) | `''`          | Options or `source` key or an array of layer `id`s from the Mapbox Style object. When a `source` key is provided, all layers for the specified source will be included in the style function. When layer `id`s are provided, they must be from layers that use the same source. When not provided or a falsey value, all layers using the first source specified in the glStyle will be rendered.                                                                                                 |
+| `optionsOrPath?`           | `string` \| [`Options`](#interfacesinternal_optionsmd) & [`ApplyStyleOptions`](#interfacesinternal_applystyleoptionsmd)                | `{}`          | **Deprecated**. Options. Alternatively the path of the style file (only required when a relative path is used for the `"sprite"` property of the style).                                                                                                                                                                                                                                                                                                                                          |
+| `resolutions?`             | `number`\[]                                                                                                                            | `undefined`   | **Deprecated**. Resolutions for mapping resolution to zoom level. Only needed when working with non-standard tile grids or projections, can also be supplied with options.                                                                                                                                                                                                                                                                                                                        |
+
+##### Returns
+
+`Promise`&lt;`any`>
+
+Promise which will be resolved when the style can be used
+for rendering.
+
+* * *
+
+#### getFeatureState
+
+▸ **getFeatureState**(`mapOrLayer`, `feature`): `any`
+
+Sets or removes a feature state. The feature state is taken into account for styling,
+just like the feature's properties, and can be used e.g. to conditionally render selected
+features differently.
+
+##### Parameters
+
+| Name         | Type                                                           | Description                               |
+| :----------- | :------------------------------------------------------------- | :---------------------------------------- |
+| `mapOrLayer` | `Map` \| `VectorLayer`&lt;`any`> \| `VectorTileLayer`          | Map or layer to set the feature state on. |
+| `feature`    | [`FeatureIdentifier`](#interfacesinternal_featureidentifiermd) | Feature identifier.                       |
+
+##### Returns
+
+`any`
+
+Feature state or `null` when no feature state is set for the given
+feature identifier.
+
+* * *
+
+#### getLayer
+
+▸ **getLayer**(`map`, `layerId`): `Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>
+
+Get the OpenLayers layer instance that contains the provided Mapbox Style
+`layer`. Note that multiple Mapbox Style layers are combined in a single
+OpenLayers layer instance when they use the same Mapbox Style `source`.
+
+##### Parameters
+
+| Name      | Type                  | Description                   |
+| :-------- | :-------------------- | :---------------------------- |
+| `map`     | `Map` \| `LayerGroup` | OpenLayers Map or LayerGroup. |
+| `layerId` | `string`              | Mapbox Style layer id.        |
+
+##### Returns
+
+`Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>
+
+OpenLayers layer instance.
+
+* * *
+
+#### getLayers
+
+▸ **getLayers**(`map`, `sourceId`): `Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>\[]
+
+Get the OpenLayers layer instances for the provided Mapbox Style `source`.
+
+##### Parameters
+
+| Name       | Type                  | Description                   |
+| :--------- | :-------------------- | :---------------------------- |
+| `map`      | `Map` \| `LayerGroup` | OpenLayers Map or LayerGroup. |
+| `sourceId` | `string`              | Mapbox Style source id.       |
+
+##### Returns
+
+`Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>\[]
+
+OpenLayers layer instances.
+
+* * *
+
+#### getMapboxLayer
+
+▸ **getMapboxLayer**(`mapOrGroup`, `layerId`): `any`
+
+Get the Mapbox Layer object for the provided `layerId`.
+
+##### Parameters
+
+| Name         | Type                  | Description        |
+| :----------- | :-------------------- | :----------------- |
+| `mapOrGroup` | `Map` \| `LayerGroup` | Map or LayerGroup. |
+| `layerId`    | `string`              | Mapbox Layer id.   |
+
+##### Returns
+
+`any`
+
+Mapbox Layer object.
+
+* * *
+
+#### getSource
+
+▸ **getSource**(`map`, `sourceId`): `Source`
+
+Get the OpenLayers source instance for the provided Mapbox Style `source`.
+
+##### Parameters
+
+| Name       | Type                  | Description                   |
+| :--------- | :-------------------- | :---------------------------- |
+| `map`      | `Map` \| `LayerGroup` | OpenLayers Map or LayerGroup. |
+| `sourceId` | `string`              | Mapbox Style source id.       |
+
+##### Returns
+
+`Source`
+
+OpenLayers source instance.
+
+* * *
+
+#### getStyleForLayer
+
+▸ **getStyleForLayer**(`feature`, `resolution`, `olLayer`, `layerId`): `Style`\[]
+
+Get the the style for a specific Mapbox layer only. This can be useful for creating a legend.
+
+##### Parameters
+
+| Name         | Type                                         | Description                                 |
+| :----------- | :------------------------------------------- | :------------------------------------------ |
+| `feature`    | `Feature`&lt;`Geometry`> \| `RenderFeature`  | OpenLayers feature.                         |
+| `resolution` | `number`                                     | View resolution.                            |
+| `olLayer`    | `VectorLayer`&lt;`any`> \| `VectorTileLayer` | OpenLayers layer.                           |
+| `layerId`    | `string`                                     | Id of the Mapbox layer to get the style for |
+
+##### Returns
+
+`Style`\[]
+
+Styles for the provided Mapbox layer.
+
+* * *
+
+#### recordStyleLayer
+
+▸ **recordStyleLayer**(`record?`): `void`
+
+Turns recording of the Mapbox Style's `layer` on and off. When turned on,
+the layer that a rendered feature belongs to will be set as the feature's
+`mapbox-layer` property.
+
+##### Parameters
+
+| Name     | Type      | Default value | Description                         |
+| :------- | :-------- | :------------ | :---------------------------------- |
+| `record` | `boolean` | `false`       | Recording of the style layer is on. |
+
+##### Returns
+
+`void`
+
+* * *
+
+#### removeMapboxLayer
+
+▸ **removeMapboxLayer**(`mapOrGroup`, `mapboxLayerIdOrLayer`): `void`
+
+Remove a Mapbox Layer object from the style. The map will be re-rendered.
+
+##### Parameters
+
+| Name                   | Type                  | Description                                  |
+| :--------------------- | :-------------------- | :------------------------------------------- |
+| `mapOrGroup`           | `Map` \| `LayerGroup` | The Map or LayerGroup `apply` was called on. |
+| `mapboxLayerIdOrLayer` | `any`                 | Mapbox Layer id or Mapbox Layer object.      |
+
+##### Returns
+
+`void`
+
+* * *
+
+#### renderTransparent
+
+▸ **renderTransparent**(`enabled`): `void`
+
+Configure whether features with a transparent style should be rendered. When
+set to `true`, it will be possible to hit detect content that is not visible,
+like transparent fills of polygons, using `ol/layer/Layer#getFeatures()` or
+`ol/Map#getFeaturesAtPixel()`
+
+##### Parameters
+
+| Name      | Type      | Description                                                       |
+| :-------- | :-------- | :---------------------------------------------------------------- |
+| `enabled` | `boolean` | Rendering of transparent elements is enabled. Default is `false`. |
+
+##### Returns
+
+`void`
+
+* * *
+
+#### setFeatureState
+
+▸ **setFeatureState**(`mapOrLayer`, `feature`, `state`): `void`
+
+Sets or removes a feature state. The feature state is taken into account for styling,
+just like the feature's properties, and can be used e.g. to conditionally render selected
+features differently.
+
+The feature state will be stored on the OpenLayers layer matching the feature identifier, in the
+`mapbox-featurestate` property.
+
+##### Parameters
+
+| Name         | Type                                                           | Description                                               |
+| :----------- | :------------------------------------------------------------- | :-------------------------------------------------------- |
+| `mapOrLayer` | `Map` \| `VectorLayer`&lt;`any`> \| `VectorTileLayer`          | OpenLayers Map or layer to set the feature state on.      |
+| `feature`    | [`FeatureIdentifier`](#interfacesinternal_featureidentifiermd) | Feature identifier.                                       |
+| `state`      | `any`                                                          | Feature state. Set to `null` to remove the feature state. |
+
+##### Returns
+
+`void`
+
+* * *
+
+#### stylefunction
+
+▸ **stylefunction**(`olLayer`, `glStyle`, `sourceOrLayers`, `resolutions?`, `spriteData?`, `spriteImageUrl?`, `getFonts?`, `getImage?`, `...args`): `StyleFunction`
+
+Creates a style function from the `glStyle` object for all layers that use
+the specified `source`, which needs to be a `"type": "vector"` or
+`"type": "geojson"` source and applies it to the specified OpenLayers layer.
+
+Two additional properties will be set on the provided layer:
+
+- `mapbox-source`: The `id` of the Mapbox Style document's source that the
+  OpenLayers layer was created from. Usually `apply()` creates one
+  OpenLayers layer per Mapbox Style source, unless the layer stack has
+  layers from different sources in between.
+- `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
+  included in the OpenLayers layer.
+
+This function also works in a web worker. In worker mode, the main thread needs
+to listen to messages from the worker and respond with another message to make
+sure that sprite image loading works:
+
+```js
+ worker.addEventListener('message', event => {
+  if (event.data.action === 'loadImage') {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.addEventListener('load', function() {
+      createImageBitmap(image, 0, 0, image.width, image.height).then(imageBitmap => {
+        worker.postMessage({
+          action: 'imageLoaded',
+          image: imageBitmap,
+          src: event.data.src
+        }, [imageBitmap]);
+      });
+    });
+    image.src = event.data.src;
+  }
+});
+```
+
+##### Parameters
+
+| Name             | Type                                                                                                                              | Default value        | Description                                                                                                                                                                                                                                                                                                                                                       |
+| :--------------- | :-------------------------------------------------------------------------------------------------------------------------------- | :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `olLayer`        | `VectorLayer`&lt;`any`> \| `VectorTileLayer`                                                                                      | `undefined`          | OpenLayers layer to apply the style to. In addition to the style, the layer will get two properties: `mapbox-source` will be the `id` of the `glStyle`'s source used for the layer, and `mapbox-layers` will be an array of the `id`s of the `glStyle`'s layers.                                                                                                  |
+| `glStyle`        | `any`                                                                                                                             | `undefined`          | Mapbox Style object.                                                                                                                                                                                                                                                                                                                                              |
+| `sourceOrLayers` | `string` \| `string`\[]                                                                                                           | `undefined`          | `source` key or an array of layer `id`s from the Mapbox Style object. When a `source` key is provided, all layers for the specified source will be included in the style function. When layer `id`s are provided, they must be from layers that use the same source.                                                                                              |
+| `resolutions`    | `number`\[]                                                                                                                       | `defaultResolutions` | Resolutions for mapping resolution to zoom level.                                                                                                                                                                                                                                                                                                                 |
+| `spriteData`     | `any`                                                                                                                             | `undefined`          | Sprite data from the url specified in the Mapbox Style object's `sprite` property. Only required if a `sprite` property is specified in the Mapbox Style object.                                                                                                                                                                                                  |
+| `spriteImageUrl` | `string`                                                                                                                          | `undefined`          | Sprite image url for the sprite specified in the Mapbox Style object's `sprite` property. Only required if a `sprite` property is specified in the Mapbox Style object.                                                                                                                                                                                           |
+| `getFonts`       | (`arg0`: `string`\[], `arg1`: `string`) => `string`\[]                                                                            | `undefined`          | Function that receives a font stack and the url template from the GL style's `metadata['ol:webfonts']` property (if set) as arguments, and returns a (modified) font stack that is available. Font names are the names used in the Mapbox Style object. If not provided, the font stack will be used as-is. This function can also be used for loading web fonts. |
+| `getImage?`      | (`arg0`: `VectorLayer`&lt;`any`> \| `VectorTileLayer`, `arg1`: `string`) => `string` \| `HTMLCanvasElement` \| `HTMLImageElement` | `undefined`          | Function that returns an image or a URL for an image name. If the result is an HTMLImageElement, it must already be loaded. The layer can be used to call layer.changed() when the loading and processing of the image has finished. This function can be used for icons not in the sprite or to override sprite icons.                                           |
+| `...args`        | `any`                                                                                                                             | `undefined`          | -                                                                                                                                                                                                                                                                                                                                                                 |
+
+##### Returns
+
+`StyleFunction`
+
+Style function for use in
+`ol.layer.Vector` or `ol.layer.VectorTile`.
+
+* * *
+
+#### updateMapboxLayer
+
+▸ **updateMapboxLayer**(`mapOrGroup`, `mapboxLayer`): `void`
+
+Update a Mapbox Layer object in the style. The map will be re-rendered with the new style.
+
+##### Parameters
+
+| Name          | Type                  | Description                                  |
+| :------------ | :-------------------- | :------------------------------------------- |
+| `mapOrGroup`  | `Map` \| `LayerGroup` | The Map or LayerGroup `apply` was called on. |
+| `mapboxLayer` | `any`                 | Updated Mapbox Layer object.                 |
+
+##### Returns
+
+`void`
+
+<a name="classesmapboxvectorlayermd"></a>
+
+## Class: MapboxVectorLayer
 
 **`Classdesc`**
 
 ```js
-import MapboxVectorLayer from 'ol-mapbox-style/MapboxVectorLayer';
+import {MapboxVectorLayer} from 'ol-mapbox-style';
 ```
 
 A vector tile layer based on a Mapbox style that uses a single vector source.  Configure
@@ -178,7 +667,7 @@ module:ol/events/Event~BaseEvent#event:error
 
 - `VectorTileLayer`
 
-  ↳ **`default`**
+  ↳ **`MapboxVectorLayer`**
 
 ### Table of contents
 
@@ -194,13 +683,13 @@ module:ol/events/Event~BaseEvent#event:error
 
 #### constructor
 
-• **new default**(`options`)
+• **new MapboxVectorLayer**(`options`)
 
 ##### Parameters
 
-| Name      | Type                                               | Description                                                                 |
-| :-------- | :------------------------------------------------- | :-------------------------------------------------------------------------- |
-| `options` | [`Options`](#interfacesmapboxvectorlayeroptionsmd) | Layer options. At a minimum, `styleUrl` and `accessToken` must be provided. |
+| Name      | Type                                         | Description                                                                 |
+| :-------- | :------------------------------------------- | :-------------------------------------------------------------------------- |
+| `options` | [`Options`](#interfacesinternal_options-1md) | Layer options. At a minimum, `styleUrl` and `accessToken` must be provided. |
 
 ##### Overrides
 
@@ -212,11 +701,81 @@ VectorTileLayer.constructor
 
 • **accessToken**: `string`
 
-<a name="interfacesmapboxvectorlayeroptionsmd"></a>
+<a name="interfacesinternal_applystyleoptionsmd"></a>
+
+## Interface: ApplyStyleOptions&lt;>
+
+[<internal>](#modulesinternal_md).ApplyStyleOptions
+
+### Table of contents
+
+#### Properties
+
+- [layers](#layers)
+- [source](#source)
+- [updateSource](#updateSource)
+
+### Properties
+
+#### layers
+
+• **layers**: `string`\[]
+
+Layers. If no source is provided, the layers with the
+provided ids will be used from the style's `layers` array. All layers need to use the same source.
+
+* * *
+
+#### source
+
+• **source**: `string`
+
+Source. Default is `''`, which causes the first source in the
+style to be used.
+
+* * *
+
+#### updateSource
+
+• **updateSource**: `boolean`
+
+Update or create vector (tile) layer source with parameters
+specified for the source in the mapbox style definition.
+
+<a name="interfacesinternal_featureidentifiermd"></a>
+
+## Interface: FeatureIdentifier&lt;>
+
+[<internal>](#modulesinternal_md).FeatureIdentifier
+
+### Table of contents
+
+#### Properties
+
+- [id](#id)
+- [source](#source)
+
+### Properties
+
+#### id
+
+• **id**: `string` \| `number`
+
+The feature id.
+
+* * *
+
+#### source
+
+• **source**: `string`
+
+The source id.
+
+<a name="interfacesinternal_options-1md"></a>
 
 ## Interface: Options&lt;>
 
-[MapboxVectorLayer](#modulesmapboxvectorlayermd).Options
+[<internal>](#modulesinternal_md).Options
 
 ### Table of contents
 
@@ -321,7 +880,7 @@ source.
 Sets the layer as overlay on a map. The map will not manage
 this layer in its layers collection, and the layer will be rendered on top. This is useful for
 temporary layers. The standard way to add a layer to a map and have it managed by the map is to
-use `map.addLayer()`[Map](#Map).
+use `map.addLayer()`.
 
 * * *
 
@@ -490,81 +1049,11 @@ will be ordered, first by Z-index and then by position. When `undefined`, a `zIn
 for layers that are added to the map's `layers` collection, or `Infinity` when the layer's `setMap()`
 method was used.
 
-<a name="interfacesmapboxvectorlayer_internal_applystyleoptionsmd"></a>
-
-## Interface: ApplyStyleOptions&lt;>
-
-[MapboxVectorLayer](#modulesmapboxvectorlayermd).[<internal>](#modulesmapboxvectorlayer_internal_md).ApplyStyleOptions
-
-### Table of contents
-
-#### Properties
-
-- [layers](#layers)
-- [source](#source)
-- [updateSource](#updateSource)
-
-### Properties
-
-#### layers
-
-• **layers**: `string`\[]
-
-Layers. If no source is provided, the layers with the
-provided ids will be used from the style's `layers` array. All layers need to use the same source.
-
-* * *
-
-#### source
-
-• **source**: `string`
-
-Source. Default is `''`, which causes the first source in the
-style to be used.
-
-* * *
-
-#### updateSource
-
-• **updateSource**: `boolean`
-
-Update or create vector (tile) layer source with parameters
-specified for the source in the mapbox style definition.
-
-<a name="interfacesmapboxvectorlayer_internal_featureidentifiermd"></a>
-
-## Interface: FeatureIdentifier&lt;>
-
-[MapboxVectorLayer](#modulesmapboxvectorlayermd).[<internal>](#modulesmapboxvectorlayer_internal_md).FeatureIdentifier
-
-### Table of contents
-
-#### Properties
-
-- [id](#id)
-- [source](#source)
-
-### Properties
-
-#### id
-
-• **id**: `string` \| `number`
-
-The feature id.
-
-* * *
-
-#### source
-
-• **source**: `string`
-
-The source id.
-
-<a name="interfacesmapboxvectorlayer_internal_optionsmd"></a>
+<a name="interfacesinternal_optionsmd"></a>
 
 ## Interface: Options&lt;>
 
-[MapboxVectorLayer](#modulesmapboxvectorlayermd).[<internal>](#modulesmapboxvectorlayer_internal_md).Options
+[<internal>](#modulesinternal_md).Options
 
 ### Table of contents
 
@@ -598,11 +1087,11 @@ Access token param. For internal use.
 
 #### getImage
 
-• **getImage**: (`arg0`: `VectorLayer`&lt;`any`> \| `VectorTileLayer`, `arg1`: `string`) => `string` \| `HTMLImageElement` \| `HTMLCanvasElement`
+• **getImage**: (`arg0`: `VectorLayer`&lt;`any`> \| `VectorTileLayer`, `arg1`: `string`) => `string` \| `HTMLCanvasElement` \| `HTMLImageElement`
 
 ##### Type declaration
 
-▸ (`arg0`, `arg1`): `string` \| `HTMLImageElement` \| `HTMLCanvasElement`
+▸ (`arg0`, `arg1`): `string` \| `HTMLCanvasElement` \| `HTMLImageElement`
 
 Function that returns an image for an icon name. If the result is an HTMLImageElement, it must already be
 loaded. The layer can be used to call layer.changed() when the loading and processing of the image has finished.
@@ -617,7 +1106,7 @@ This function be used for icons not in the sprite or to override sprite icons.
 
 ###### Returns
 
-`string` \| `HTMLImageElement` \| `HTMLCanvasElement`
+`string` \| `HTMLCanvasElement` \| `HTMLImageElement`
 
 * * *
 
@@ -677,7 +1166,7 @@ the returned request will be respected.
 
 `void` \| `Request`
 
-<a name="modulesmapboxvectorlayer_internal_md"></a>
+<a name="modulesinternal_md"></a>
 
 ## Module: &lt;internal>
 
@@ -685,9 +1174,10 @@ the returned request will be respected.
 
 #### Interfaces
 
-- [ApplyStyleOptions](#interfacesmapboxvectorlayer_internal_applystyleoptionsmd)
-- [FeatureIdentifier](#interfacesmapboxvectorlayer_internal_featureidentifiermd)
-- [Options](#interfacesmapboxvectorlayer_internal_optionsmd)
+- [ApplyStyleOptions](#interfacesinternal_applystyleoptionsmd)
+- [FeatureIdentifier](#interfacesinternal_featureidentifiermd)
+- [Options](#interfacesinternal_optionsmd)
+- [Options](#interfacesinternal_options-1md)
 
 #### Type Aliases
 
@@ -698,525 +1188,3 @@ the returned request will be respected.
 #### ResourceType
 
 Ƭ **ResourceType**&lt;>: `"Style"` \| `"Source"` \| `"Sprite"` \| `"SpriteImage"` \| `"Tiles"` \| `"GeoJSON"`
-
-<a name="modulesmapboxvectorlayermd"></a>
-
-## Module: MapboxVectorLayer
-
-### Table of contents
-
-#### Modules
-
-- [&lt;internal\\>](#modulesmapboxvectorlayer_internal_md)
-
-#### Classes
-
-- [default](#classesmapboxvectorlayerdefaultmd)
-
-#### Interfaces
-
-- [Options](#interfacesmapboxvectorlayeroptionsmd)
-
-#### Type Aliases
-
-- [Map](#Map)
-
-### Type Aliases
-
-#### Map
-
-Ƭ **Map**&lt;>: `default`
-
-<a name="modulesindexmd"></a>
-
-## Module: index
-
-### Table of contents
-
-#### References
-
-- [default](#default)
-
-#### Functions
-
-- [addMapboxLayer](#addMapboxLayer)
-- [apply](#apply)
-- [applyBackground](#applyBackground)
-- [applyStyle](#applyStyle)
-- [getFeatureState](#getFeatureState)
-- [getLayer](#getLayer)
-- [getLayers](#getLayers)
-- [getMapboxLayer](#getMapboxLayer)
-- [getSource](#getSource)
-- [getStyleForLayer](#getStyleForLayer)
-- [recordStyleLayer](#recordStyleLayer)
-- [removeMapboxLayer](#removeMapboxLayer)
-- [renderTransparent](#renderTransparent)
-- [setFeatureState](#setFeatureState)
-- [stylefunction](#stylefunction)
-- [updateMapboxLayer](#updateMapboxLayer)
-
-### References
-
-#### default
-
-Renames and re-exports [apply](#apply)
-
-### Functions
-
-#### addMapboxLayer
-
-▸ **addMapboxLayer**(`mapOrGroup`, `mapboxLayer`, `beforeLayerId?`): `Promise`&lt;`void`>
-
-Add a new Mapbox Layer object to the style. The map will be re-rendered.
-
-##### Parameters
-
-| Name             | Type                  | Description                                                              |
-| :--------------- | :-------------------- | :----------------------------------------------------------------------- |
-| `mapOrGroup`     | `Map` \| `LayerGroup` | The Map or LayerGroup `apply` was called on.                             |
-| `mapboxLayer`    | `any`                 | Mapbox Layer object.                                                     |
-| `beforeLayerId?` | `string`              | Optional id of the Mapbox Layer before the new layer that will be added. |
-
-##### Returns
-
-`Promise`&lt;`void`>
-
-Resolves when the added layer is available.
-
-* * *
-
-#### apply
-
-▸ **apply**(`mapOrGroupOrElement`, `style`, `options?`): `Promise`&lt;`Map` \| `LayerGroup`>
-
-Loads and applies a Mapbox Style object into an OpenLayers Map or LayerGroup.
-This includes the map background, the layers, and for Map instances that did not
-have a View defined yet also the center and the zoom.
-
-**Example:**
-
-```js
-import apply from 'ol-mapbox-style';
-
-apply('map', 'mapbox://styles/mapbox/bright-v9', {accessToken: 'YOUR_MAPBOX_TOKEN'});
-```
-
-The center and zoom will only be set if present in the Mapbox Style document,
-and if not already set on the OpenLayers map.
-
-Layers will be added to the OpenLayers map, without affecting any layers that
-might already be set on the map.
-
-Layers added by `apply()` will have two additional properties:
-
-- `mapbox-source`: The `id` of the Mapbox Style document's source that the
-  OpenLayers layer was created from. Usually `apply()` creates one
-  OpenLayers layer per Mapbox Style source, unless the layer stack has
-  layers from different sources in between.
-- `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
-  included in the OpenLayers layer.
-
-This function sets an additional `mapbox-style` property on the OpenLayers
-Map or LayerGroup instance, which holds the Mapbox Style object.
-
-##### Parameters
-
-| Name                  | Type                                                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| :-------------------- | :----------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mapOrGroupOrElement` | `string` \| `HTMLElement` \| `Map` \| `LayerGroup`           | Either an existing OpenLayers Map instance, or a HTML element, or the id of a HTML element that will be the target of a new OpenLayers Map, or a layer group. If layer group, styles releated to the map and view will be ignored.                                                                                                                                                                                                                                                                                                                                    |
-| `style`               | `any`                                                        | JSON style object or style url pointing to a Mapbox Style object. When using Mapbox APIs, the url is the `styleUrl` shown in Mapbox Studio's "share" panel. In addition, the `accessToken` option (see below) must be set. When passed as JSON style object, all OpenLayers layers created by `apply()` will be immediately available, but they may not have a source yet (i.e. when they are defined by a TileJSON url in the Mapbox Style document). When passed as style url, layers will be added to the map when the Mapbox Style document is loaded and parsed. |
-| `options`             | [`Options`](#interfacesmapboxvectorlayer_internal_optionsmd) | Options.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-
-##### Returns
-
-`Promise`&lt;`Map` \| `LayerGroup`>
-
-A promise that resolves after all layers have been added to
-the OpenLayers Map instance or LayerGroup, their sources set, and their styles applied. The
-`resolve` callback will be called with the OpenLayers Map instance or LayerGroup as
-argument.
-
-* * *
-
-#### applyBackground
-
-▸ **applyBackground**(`mapOrLayer`, `glStyle`, `options?`): `Promise`&lt;`any`>
-
-Applies properties of the Mapbox Style's first `background` layer to the
-provided map or layer (group).
-
-**Example:**
-
-```js
-import {applyBackground} from 'ol-mapbox-style';
-import {Map} from 'ol';
-
-const map = new Map({target: 'map'});
-applyBackground(map, 'https://api.maptiler.com/maps/basic/style.json?key=YOUR_OPENMAPTILES_TOKEN');
-```
-
-##### Parameters
-
-| Name         | Type                                                         | Description                      |
-| :----------- | :----------------------------------------------------------- | :------------------------------- |
-| `mapOrLayer` | `Map` \| `BaseLayer`                                         | OpenLayers Map or layer (group). |
-| `glStyle`    | `any`                                                        | Mapbox Style object or url.      |
-| `options`    | [`Options`](#interfacesmapboxvectorlayer_internal_optionsmd) | Options.                         |
-
-##### Returns
-
-`Promise`&lt;`any`>
-
-Promise that resolves when the background is applied.
-
-* * *
-
-#### applyStyle
-
-▸ **applyStyle**(`layer`, `glStyle`, `sourceOrLayersOrOptions?`, `optionsOrPath?`, `resolutions?`): `Promise`&lt;`any`>
-
-Applies a style function to an `ol/layer/VectorTile` or `ol/layer/Vector`
-with an `ol/source/VectorTile` or an `ol/source/Vector`. If the layer does not have a source
-yet, it will be created and populated from the information in the `glStyle` (unless `updateSource` is
-set to `false`).
-
-**Example:**
-
-```js
-import {applyStyle} from 'ol-mapbox-style';
-import {VectorTile} from 'ol/layer.js';
-
-const layer = new VectorTile({declutter: true});
-applyStyle(layer, 'https://api.maptiler.com/maps/basic/style.json?key=YOUR_OPENMAPTILES_TOKEN');
-```
-
-The style function will render all layers from the `glStyle` object that use the source
-of the first layer, the specified `source`, or a subset of layers from the same source. The
-source needs to be a `"type": "vector"` or `"type": "geojson"` source.
-
-Two additional properties will be set on the provided layer:
-
-- `mapbox-source`: The `id` of the Mapbox Style document's source that the
-  OpenLayers layer was created from. Usually `apply()` creates one
-  OpenLayers layer per Mapbox Style source, unless the layer stack has
-  layers from different sources in between.
-- `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
-  included in the OpenLayers layer.
-
-##### Parameters
-
-| Name                       | Type                                                                                                                                                                       | Default value | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| :------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `layer`                    | `VectorLayer`&lt;`any`> \| `VectorTileLayer`                                                                                                                               | `undefined`   | OpenLayers layer. When the layer has a source configured, it will be modified to use the configuration from the glStyle's `source`. Options specified on the layer's source will override those from the glStyle's `source`, except for `url` and `tileUrlFunction`. When the source projection is the default (`EPSG:3857`), the `tileGrid` will also be overridden. If you'd rather not have ol-mapbox-style modify the source, configure `applyStyle()` with the `updateSource: false` option. |
-| `glStyle`                  | `any`                                                                                                                                                                      | `undefined`   | Mapbox Style object.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `sourceOrLayersOrOptions?` | `string` \| `string`\[] \| [`Options`](#interfacesmapboxvectorlayer_internal_optionsmd) & [`ApplyStyleOptions`](#interfacesmapboxvectorlayer_internal_applystyleoptionsmd) | `''`          | Options or `source` key or an array of layer `id`s from the Mapbox Style object. When a `source` key is provided, all layers for the specified source will be included in the style function. When layer `id`s are provided, they must be from layers that use the same source. When not provided or a falsey value, all layers using the first source specified in the glStyle will be rendered.                                                                                                 |
-| `optionsOrPath?`           | `string` \| [`Options`](#interfacesmapboxvectorlayer_internal_optionsmd) & [`ApplyStyleOptions`](#interfacesmapboxvectorlayer_internal_applystyleoptionsmd)                | `{}`          | **Deprecated**. Options. Alternatively the path of the style file (only required when a relative path is used for the `"sprite"` property of the style).                                                                                                                                                                                                                                                                                                                                          |
-| `resolutions?`             | `number`\[]                                                                                                                                                                | `undefined`   | **Deprecated**. Resolutions for mapping resolution to zoom level. Only needed when working with non-standard tile grids or projections, can also be supplied with options.                                                                                                                                                                                                                                                                                                                        |
-
-##### Returns
-
-`Promise`&lt;`any`>
-
-Promise which will be resolved when the style can be used
-for rendering.
-
-* * *
-
-#### getFeatureState
-
-▸ **getFeatureState**(`mapOrLayer`, `feature`): `any`
-
-Sets or removes a feature state. The feature state is taken into account for styling,
-just like the feature's properties, and can be used e.g. to conditionally render selected
-features differently.
-
-##### Parameters
-
-| Name         | Type                                                                             | Description                               |
-| :----------- | :------------------------------------------------------------------------------- | :---------------------------------------- |
-| `mapOrLayer` | `VectorLayer`&lt;`any`> \| `VectorTileLayer` \| `Map`                            | Map or layer to set the feature state on. |
-| `feature`    | [`FeatureIdentifier`](#interfacesmapboxvectorlayer_internal_featureidentifiermd) | Feature identifier.                       |
-
-##### Returns
-
-`any`
-
-Feature state or `null` when no feature state is set for the given
-feature identifier.
-
-* * *
-
-#### getLayer
-
-▸ **getLayer**(`map`, `layerId`): `Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>
-
-Get the OpenLayers layer instance that contains the provided Mapbox Style
-`layer`. Note that multiple Mapbox Style layers are combined in a single
-OpenLayers layer instance when they use the same Mapbox Style `source`.
-
-##### Parameters
-
-| Name      | Type                  | Description                   |
-| :-------- | :-------------------- | :---------------------------- |
-| `map`     | `Map` \| `LayerGroup` | OpenLayers Map or LayerGroup. |
-| `layerId` | `string`              | Mapbox Style layer id.        |
-
-##### Returns
-
-`Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>
-
-OpenLayers layer instance.
-
-* * *
-
-#### getLayers
-
-▸ **getLayers**(`map`, `sourceId`): `Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>\[]
-
-Get the OpenLayers layer instances for the provided Mapbox Style `source`.
-
-##### Parameters
-
-| Name       | Type                  | Description                   |
-| :--------- | :-------------------- | :---------------------------- |
-| `map`      | `Map` \| `LayerGroup` | OpenLayers Map or LayerGroup. |
-| `sourceId` | `string`              | Mapbox Style source id.       |
-
-##### Returns
-
-`Layer`&lt;`Source`, `LayerRenderer`&lt;`any`>>\[]
-
-OpenLayers layer instances.
-
-* * *
-
-#### getMapboxLayer
-
-▸ **getMapboxLayer**(`mapOrGroup`, `layerId`): `any`
-
-Get the Mapbox Layer object for the provided `layerId`.
-
-##### Parameters
-
-| Name         | Type                  | Description        |
-| :----------- | :-------------------- | :----------------- |
-| `mapOrGroup` | `Map` \| `LayerGroup` | Map or LayerGroup. |
-| `layerId`    | `string`              | Mapbox Layer id.   |
-
-##### Returns
-
-`any`
-
-Mapbox Layer object.
-
-* * *
-
-#### getSource
-
-▸ **getSource**(`map`, `sourceId`): `Source`
-
-Get the OpenLayers source instance for the provided Mapbox Style `source`.
-
-##### Parameters
-
-| Name       | Type                  | Description                   |
-| :--------- | :-------------------- | :---------------------------- |
-| `map`      | `Map` \| `LayerGroup` | OpenLayers Map or LayerGroup. |
-| `sourceId` | `string`              | Mapbox Style source id.       |
-
-##### Returns
-
-`Source`
-
-OpenLayers source instance.
-
-* * *
-
-#### getStyleForLayer
-
-▸ **getStyleForLayer**(`feature`, `resolution`, `olLayer`, `layerId`): `Style`\[]
-
-Get the the style for a specific Mapbox layer only. This can be useful for creating a legend.
-
-##### Parameters
-
-| Name         | Type                                         | Description                                 |
-| :----------- | :------------------------------------------- | :------------------------------------------ |
-| `feature`    | `RenderFeature` \| `Feature`&lt;`Geometry`>  | OpenLayers feature.                         |
-| `resolution` | `number`                                     | View resolution.                            |
-| `olLayer`    | `VectorLayer`&lt;`any`> \| `VectorTileLayer` | OpenLayers layer.                           |
-| `layerId`    | `string`                                     | Id of the Mapbox layer to get the style for |
-
-##### Returns
-
-`Style`\[]
-
-Styles for the provided Mapbox layer.
-
-* * *
-
-#### recordStyleLayer
-
-▸ **recordStyleLayer**(`record?`): `void`
-
-Turns recording of the Mapbox Style's `layer` on and off. When turned on,
-the layer that a rendered feature belongs to will be set as the feature's
-`mapbox-layer` property.
-
-##### Parameters
-
-| Name     | Type      | Default value | Description                         |
-| :------- | :-------- | :------------ | :---------------------------------- |
-| `record` | `boolean` | `false`       | Recording of the style layer is on. |
-
-##### Returns
-
-`void`
-
-* * *
-
-#### removeMapboxLayer
-
-▸ **removeMapboxLayer**(`mapOrGroup`, `mapboxLayerIdOrLayer`): `void`
-
-Remove a Mapbox Layer object from the style. The map will be re-rendered.
-
-##### Parameters
-
-| Name                   | Type                  | Description                                  |
-| :--------------------- | :-------------------- | :------------------------------------------- |
-| `mapOrGroup`           | `Map` \| `LayerGroup` | The Map or LayerGroup `apply` was called on. |
-| `mapboxLayerIdOrLayer` | `any`                 | Mapbox Layer id or Mapbox Layer object.      |
-
-##### Returns
-
-`void`
-
-* * *
-
-#### renderTransparent
-
-▸ **renderTransparent**(`enabled`): `void`
-
-Configure whether features with a transparent style should be rendered. When
-set to `true`, it will be possible to hit detect content that is not visible,
-like transparent fills of polygons, using `ol/layer/Layer#getFeatures()` or
-`ol/Map#getFeaturesAtPixel()`
-
-##### Parameters
-
-| Name      | Type      | Description                                                       |
-| :-------- | :-------- | :---------------------------------------------------------------- |
-| `enabled` | `boolean` | Rendering of transparent elements is enabled. Default is `false`. |
-
-##### Returns
-
-`void`
-
-* * *
-
-#### setFeatureState
-
-▸ **setFeatureState**(`mapOrLayer`, `feature`, `state`): `void`
-
-Sets or removes a feature state. The feature state is taken into account for styling,
-just like the feature's properties, and can be used e.g. to conditionally render selected
-features differently.
-
-The feature state will be stored on the OpenLayers layer matching the feature identifier, in the
-`mapbox-featurestate` property.
-
-##### Parameters
-
-| Name         | Type                                                                             | Description                                               |
-| :----------- | :------------------------------------------------------------------------------- | :-------------------------------------------------------- |
-| `mapOrLayer` | `VectorLayer`&lt;`any`> \| `VectorTileLayer` \| `Map`                            | OpenLayers Map or layer to set the feature state on.      |
-| `feature`    | [`FeatureIdentifier`](#interfacesmapboxvectorlayer_internal_featureidentifiermd) | Feature identifier.                                       |
-| `state`      | `any`                                                                            | Feature state. Set to `null` to remove the feature state. |
-
-##### Returns
-
-`void`
-
-* * *
-
-#### stylefunction
-
-▸ **stylefunction**(`olLayer`, `glStyle`, `sourceOrLayers`, `resolutions?`, `spriteData?`, `spriteImageUrl?`, `getFonts?`, `getImage?`, `...args`): `StyleFunction`
-
-Creates a style function from the `glStyle` object for all layers that use
-the specified `source`, which needs to be a `"type": "vector"` or
-`"type": "geojson"` source and applies it to the specified OpenLayers layer.
-
-Two additional properties will be set on the provided layer:
-
-- `mapbox-source`: The `id` of the Mapbox Style document's source that the
-  OpenLayers layer was created from. Usually `apply()` creates one
-  OpenLayers layer per Mapbox Style source, unless the layer stack has
-  layers from different sources in between.
-- `mapbox-layers`: The `id`s of the Mapbox Style document's layers that are
-  included in the OpenLayers layer.
-
-This function also works in a web worker. In worker mode, the main thread needs
-to listen to messages from the worker and respond with another message to make
-sure that sprite image loading works:
-
-```js
- worker.addEventListener('message', event => {
-  if (event.data.action === 'loadImage') {
-    const image = new Image();
-    image.crossOrigin = 'anonymous';
-    image.addEventListener('load', function() {
-      createImageBitmap(image, 0, 0, image.width, image.height).then(imageBitmap => {
-        worker.postMessage({
-          action: 'imageLoaded',
-          image: imageBitmap,
-          src: event.data.src
-        }, [imageBitmap]);
-      });
-    });
-    image.src = event.data.src;
-  }
-});
-```
-
-##### Parameters
-
-| Name             | Type                                                                                                                              | Default value        | Description                                                                                                                                                                                                                                                                                                                                                       |
-| :--------------- | :-------------------------------------------------------------------------------------------------------------------------------- | :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `olLayer`        | `VectorLayer`&lt;`any`> \| `VectorTileLayer`                                                                                      | `undefined`          | OpenLayers layer to apply the style to. In addition to the style, the layer will get two properties: `mapbox-source` will be the `id` of the `glStyle`'s source used for the layer, and `mapbox-layers` will be an array of the `id`s of the `glStyle`'s layers.                                                                                                  |
-| `glStyle`        | `any`                                                                                                                             | `undefined`          | Mapbox Style object.                                                                                                                                                                                                                                                                                                                                              |
-| `sourceOrLayers` | `string` \| `string`\[]                                                                                                           | `undefined`          | `source` key or an array of layer `id`s from the Mapbox Style object. When a `source` key is provided, all layers for the specified source will be included in the style function. When layer `id`s are provided, they must be from layers that use the same source.                                                                                              |
-| `resolutions`    | `number`\[]                                                                                                                       | `defaultResolutions` | Resolutions for mapping resolution to zoom level.                                                                                                                                                                                                                                                                                                                 |
-| `spriteData`     | `any`                                                                                                                             | `undefined`          | Sprite data from the url specified in the Mapbox Style object's `sprite` property. Only required if a `sprite` property is specified in the Mapbox Style object.                                                                                                                                                                                                  |
-| `spriteImageUrl` | `string`                                                                                                                          | `undefined`          | Sprite image url for the sprite specified in the Mapbox Style object's `sprite` property. Only required if a `sprite` property is specified in the Mapbox Style object.                                                                                                                                                                                           |
-| `getFonts`       | (`arg0`: `string`\[], `arg1`: `string`) => `string`\[]                                                                            | `undefined`          | Function that receives a font stack and the url template from the GL style's `metadata['ol:webfonts']` property (if set) as arguments, and returns a (modified) font stack that is available. Font names are the names used in the Mapbox Style object. If not provided, the font stack will be used as-is. This function can also be used for loading web fonts. |
-| `getImage?`      | (`arg0`: `VectorLayer`&lt;`any`> \| `VectorTileLayer`, `arg1`: `string`) => `string` \| `HTMLImageElement` \| `HTMLCanvasElement` | `undefined`          | Function that returns an image or a URL for an image name. If the result is an HTMLImageElement, it must already be loaded. The layer can be used to call layer.changed() when the loading and processing of the image has finished. This function can be used for icons not in the sprite or to override sprite icons.                                           |
-| `...args`        | `any`                                                                                                                             | `undefined`          | -                                                                                                                                                                                                                                                                                                                                                                 |
-
-##### Returns
-
-`StyleFunction`
-
-Style function for use in
-`ol.layer.Vector` or `ol.layer.VectorTile`.
-
-* * *
-
-#### updateMapboxLayer
-
-▸ **updateMapboxLayer**(`mapOrGroup`, `mapboxLayer`): `void`
-
-Update a Mapbox Layer object in the style. The map will be re-rendered with the new style.
-
-##### Parameters
-
-| Name          | Type                  | Description                                  |
-| :------------ | :-------------------- | :------------------------------------------- |
-| `mapOrGroup`  | `Map` \| `LayerGroup` | The Map or LayerGroup `apply` was called on. |
-| `mapboxLayer` | `any`                 | Updated Mapbox Layer object.                 |
-
-##### Returns
-
-`void`

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@mapbox/flow-remove-types": "^2.0.0",
-        "@rollup/plugin-buble": "^1.0.1",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@types/arcgis-rest-api": "^10.4.4",
@@ -24,8 +23,6 @@
         "@types/topojson-specification": "^1.0.1",
         "add-text-to-markdown": "^2.0.0",
         "babel-loader": "^9.1.0",
-        "buble": "^0.20.0",
-        "buble-loader": "^0.5.1",
         "concat-md": "^0.5.0",
         "copy-webpack-plugin": "^11.0.0",
         "coverage-istanbul-loader": "^3.0.5",
@@ -52,7 +49,6 @@
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-unassert": "^0.6.0",
         "should": "^13.2.3",
-        "shx": "^0.3.4",
         "sinon": "^15.0.1",
         "style-loader": "^3.3.1",
         "typedoc": "0.24.x",
@@ -117,9 +113,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -858,28 +854,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@rollup/plugin-buble": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-buble/-/plugin-buble-1.0.2.tgz",
-      "integrity": "sha512-Hz9+AigRWwS93vmorrVrhyG9SdSCZAkBDx614w09iFQYFUAP2HmdUrQyZsb1WO2n+iDvPFznrTE16la+eGNcEQ==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/buble": "^0.19.2",
-        "buble": "^0.20.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.3.tgz",
@@ -1106,15 +1080,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/buble": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@types/buble/-/buble-0.19.2.tgz",
-      "integrity": "sha512-uUD8zIfXMKThmFkahTXDGI3CthFH1kMg2dOm3KLi4GlC5cbARA64bEcUMbbWdWdE73eoc/iBB9PiTMqH0dNS2Q==",
-      "dev": true,
-      "dependencies": {
-        "magic-string": "^0.25.0"
       }
     },
     "node_modules/@types/connect": {
@@ -1584,20 +1549,12 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true,
-      "peerDependencies": {
-        "acorn": "^6.0.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -1786,9 +1743,9 @@
       }
     },
     "node_modules/add-text-to-markdown/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2338,37 +2295,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
-      }
-    },
-    "node_modules/buble": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.20.0.tgz",
-      "integrity": "sha512-/1gnaMQE8xvd5qsNBl+iTuyjJ9XxeaVxAMF86dQ4EyxFJOZtsgOS8Ra+7WHgZTam5IFDtt4BguN0sH0tVTKrOw==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^6.4.1",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-jsx": "^5.2.0",
-        "chalk": "^2.4.2",
-        "magic-string": "^0.25.7",
-        "minimist": "^1.2.5",
-        "regexpu-core": "4.5.4"
-      },
-      "bin": {
-        "buble": "bin/buble"
-      }
-    },
-    "node_modules/buble-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/buble-loader/-/buble-loader-0.5.1.tgz",
-      "integrity": "sha512-ytp2BqL4NfyImoXQUFcIkM2EgKJI2e8KEc9R5/7MbUmdu952CYkhkwydZcKreuC6VAUBp9R7rxS88TZ7RQq/3A==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^1.1.0"
-      },
-      "peerDependencies": {
-        "buble": "*",
-        "webpack": "*"
       }
     },
     "node_modules/buffer": {
@@ -3157,9 +3083,9 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4067,9 +3993,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6410,9 +6336,9 @@
       }
     },
     "node_modules/istanbul-lib-source-maps/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -7021,15 +6947,6 @@
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
-    },
-    "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.4"
-      }
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -8199,9 +8116,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -9334,9 +9251,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -9401,68 +9318,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/regenerate": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "dev": true
-    },
-    "node_modules/regenerate-unicode-properties": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-      "dev": true,
-      "dependencies": {
-        "regenerate": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/regexpu-core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-      "dev": true,
-      "dependencies": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/regjsgen": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
-      "dev": true
-    },
-    "node_modules/regjsparser": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.9.tgz",
-      "integrity": "sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==",
-      "dev": true,
-      "dependencies": {
-        "jsesc": "~0.5.0"
-      },
-      "bin": {
-        "regjsparser": "bin/parser"
-      }
-    },
-    "node_modules/regjsparser/node_modules/jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
       }
     },
     "node_modules/relateurl": {
@@ -9980,9 +9835,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -10177,44 +10032,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/shelljs/node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/shelljs/node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/shellsubstitute": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
@@ -10286,22 +10103,6 @@
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
-    },
-    "node_modules/shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
-      },
-      "bin": {
-        "shx": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -10547,12 +10348,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -11344,46 +11139,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dev": true,
-      "dependencies": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-property-aliases-ecmascript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/unified": {
@@ -12445,9 +12200,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -13017,17 +12772,6 @@
         }
       }
     },
-    "@rollup/plugin-buble": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-buble/-/plugin-buble-1.0.2.tgz",
-      "integrity": "sha512-Hz9+AigRWwS93vmorrVrhyG9SdSCZAkBDx614w09iFQYFUAP2HmdUrQyZsb1WO2n+iDvPFznrTE16la+eGNcEQ==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/buble": "^0.19.2",
-        "buble": "^0.20.0"
-      }
-    },
     "@rollup/plugin-commonjs": {
       "version": "25.0.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.3.tgz",
@@ -13213,15 +12957,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/buble": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@types/buble/-/buble-0.19.2.tgz",
-      "integrity": "sha512-uUD8zIfXMKThmFkahTXDGI3CthFH1kMg2dOm3KLi4GlC5cbARA64bEcUMbbWdWdE73eoc/iBB9PiTMqH0dNS2Q==",
-      "dev": true,
-      "requires": {
-        "magic-string": "^0.25.0"
       }
     },
     "@types/connect": {
@@ -13664,14 +13399,8 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "dev": true
-    },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
       "dev": true,
-      "requires": {}
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -13821,9 +13550,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "strip-indent": {
@@ -14232,30 +13961,6 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
-      }
-    },
-    "buble": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.20.0.tgz",
-      "integrity": "sha512-/1gnaMQE8xvd5qsNBl+iTuyjJ9XxeaVxAMF86dQ4EyxFJOZtsgOS8Ra+7WHgZTam5IFDtt4BguN0sH0tVTKrOw==",
-      "dev": true,
-      "requires": {
-        "acorn": "^6.4.1",
-        "acorn-dynamic-import": "^4.0.0",
-        "acorn-jsx": "^5.2.0",
-        "chalk": "^2.4.2",
-        "magic-string": "^0.25.7",
-        "minimist": "^1.2.5",
-        "regexpu-core": "4.5.4"
-      }
-    },
-    "buble-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/buble-loader/-/buble-loader-0.5.1.tgz",
-      "integrity": "sha512-ytp2BqL4NfyImoXQUFcIkM2EgKJI2e8KEc9R5/7MbUmdu952CYkhkwydZcKreuC6VAUBp9R7rxS88TZ7RQq/3A==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0"
       }
     },
     "buffer": {
@@ -14832,9 +14537,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -15688,9 +15393,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -17209,9 +16914,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "source-map": {
@@ -17704,15 +17409,6 @@
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
-    },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
     },
     "make-dir": {
       "version": "3.1.0",
@@ -18578,9 +18274,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -19353,9 +19049,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "type-fest": {
@@ -19469,58 +19165,6 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
-      }
-    },
-    "regenerate": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "dev": true
-    },
-    "regenerate-unicode-properties": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.4.0"
-      }
-    },
-    "regexpu-core": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-      "integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.0.2",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.1.0"
-      }
-    },
-    "regjsgen": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-      "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.9.tgz",
-      "integrity": "sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
-          "dev": true
-        }
       }
     },
     "relateurl": {
@@ -19918,9 +19562,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "send": {
@@ -20088,34 +19732,6 @@
       "integrity": "sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "dependencies": {
-        "interpret": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-          "dev": true
-        },
-        "rechoir": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-          "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.1.6"
-          }
-        }
-      }
-    },
     "shellsubstitute": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
@@ -20187,16 +19803,6 @@
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
-    },
-    "shx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.3",
-        "shelljs": "^0.8.5"
-      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -20394,12 +20000,6 @@
           "dev": true
         }
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -20998,34 +20598,6 @@
         "inherits": "^2.0.0",
         "xtend": "^4.0.0"
       }
-    },
-    "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-      "dev": true
-    },
-    "unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "dev": true,
-      "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      }
-    },
-    "unicode-match-property-value-ecmascript": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
-      "dev": true
-    },
-    "unicode-property-aliases-ecmascript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
-      "dev": true
     },
     "unified": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/olms.js"
-    },
-    "./MapboxVectorLayer": "./dist/MapboxVectorLayer.js"
+    }
   },
   "repository": {
     "type": "git",
@@ -30,8 +29,8 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.config.examples.cjs",
     "prepare": "npm run doc && npm run build",
-    "build": "tsc --project tsconfig-build.json && rollup -c && cross-env esm=true rollup -c && shx cp src/MapboxVectorLayer.* dist/ && webpack-cli --mode=production --config ./webpack.config.examples.cjs",
-    "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-plugin-missing-exports src/index.js src/MapboxVectorLayer.js --readme none --excludeExternals --preserveAnchorCasing --hideBreadcrumbs --disableSources --tsconfig tsconfig-typecheck.json && npx concat-md docs --hide-anchor-links=false | npx add-text-to-markdown README.md --section \"API\" --write",
+    "build": "tsc --project tsconfig-build.json && rollup -c && cross-env esm=true rollup -c && webpack-cli --mode=production --config ./webpack.config.examples.cjs",
+    "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-plugin-missing-exports src/index.js --readme none --excludeExternals --preserveAnchorCasing --hideBreadcrumbs --disableSources --tsconfig tsconfig-typecheck.json && npx concat-md docs --hide-anchor-links=false | npx add-text-to-markdown README.md --section \"API\" --write",
     "karma": "karma start test/karma.conf.cjs",
     "lint": "eslint test examples src",
     "typecheck": "tsc --project tsconfig-typecheck.json",
@@ -45,7 +44,6 @@
   },
   "devDependencies": {
     "@mapbox/flow-remove-types": "^2.0.0",
-    "@rollup/plugin-buble": "^1.0.1",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@types/arcgis-rest-api": "^10.4.4",
@@ -54,8 +52,6 @@
     "@types/topojson-specification": "^1.0.1",
     "add-text-to-markdown": "^2.0.0",
     "babel-loader": "^9.1.0",
-    "buble": "^0.20.0",
-    "buble-loader": "^0.5.1",
     "concat-md": "^0.5.0",
     "copy-webpack-plugin": "^11.0.0",
     "coverage-istanbul-loader": "^3.0.5",
@@ -82,7 +78,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-unassert": "^0.6.0",
     "should": "^13.2.3",
-    "shx": "^0.3.4",
     "sinon": "^15.0.1",
     "style-loader": "^3.3.1",
     "typedoc": "0.24.x",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import buble from '@rollup/plugin-buble';
 import unassert from 'rollup-plugin-unassert';
 import flowRemoveTypes from '@mapbox/flow-remove-types';
 import {terser} from 'rollup-plugin-terser';
@@ -48,11 +47,6 @@ const config = [{
       }
     },
     unassert(),
-    buble({
-      transforms: {
-        dangerousForOf: true,
-      }
-    }),
     resolve({
       browser: true,
       preferBuiltins: false

--- a/src/MapboxVectorLayer.js
+++ b/src/MapboxVectorLayer.js
@@ -3,7 +3,7 @@ import EventType from 'ol/events/EventType.js';
 import MVT from 'ol/format/MVT.js';
 import VectorTileLayer from 'ol/layer/VectorTile.js';
 import VectorTileSource from 'ol/source/VectorTile.js';
-import {applyBackground, applyStyle} from './index.js';
+import {applyBackground, applyStyle} from './apply.js';
 
 /** @typedef {import("ol/Map.js").default} Map */
 
@@ -90,7 +90,7 @@ class ErrorEvent extends BaseEvent {
  * @property {import("ol/Map.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use `map.addLayer()`{@link Map}.
+ * use `map.addLayer()`.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
  * recreated during animations. This means that no vectors will be shown clipped, but the setting
  * will have a performance impact for large amounts of vector data. When set to `false`, batches
@@ -106,7 +106,7 @@ class ErrorEvent extends BaseEvent {
 /**
  * @classdesc
  * ```js
- * import MapboxVectorLayer from 'ol-mapbox-style/MapboxVectorLayer';
+ * import {MapboxVectorLayer} from 'ol-mapbox-style';
  * ```
  * A vector tile layer based on a Mapbox style that uses a single vector source.  Configure
  * the layer with the `styleUrl` and `accessToken` shown in Mapbox Studio's share panel.

--- a/src/index.js
+++ b/src/index.js
@@ -19,3 +19,4 @@ export {
   getFeatureState,
   setFeatureState,
 } from './apply.js';
+export {default as MapboxVectorLayer} from './MapboxVectorLayer.js';

--- a/webpack.config.examples.cjs
+++ b/webpack.config.examples.cjs
@@ -122,16 +122,6 @@ module.exports = (env, argv) => {
             'mapbox-gl-style-spec'
           ),
         },
-        {
-          test: /\.js$/,
-          use: {
-            loader: 'buble-loader',
-            options: {
-              transforms: {dangerousForOf: true},
-              objectAssign: 'Object.assign',
-            },
-          },
-        },
       ],
     },
     plugins: [


### PR DESCRIPTION
By getting rid of buble transpilation, we can now export the new MapboxVectorLayer with the index module.