### PR TITLE
Accept Promise as return type for transformRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ sure that sprite image loading works:
 | `sourceOrLayers` | `string` \| `string`\[]                                                                                                           | `undefined`          | `source` key or an array of layer `id`s from the Mapbox Style object. When a `source` key is provided, all layers for the specified source will be included in the style function. When layer `id`s are provided, they must be from layers that use the same source.                                                                                              |
 | `resolutions`    | `number`\[]                                                                                                                       | `defaultResolutions` | Resolutions for mapping resolution to zoom level.                                                                                                                                                                                                                                                                                                                 |
 | `spriteData`     | `any`                                                                                                                             | `undefined`          | Sprite data from the url specified in the Mapbox Style object's `sprite` property. Only required if a `sprite` property is specified in the Mapbox Style object.                                                                                                                                                                                                  |
-| `spriteImageUrl` | `string` \| `Request`                                                                                                             | `undefined`          | Sprite image url for the sprite specified in the Mapbox Style object's `sprite` property. Only required if a `sprite` property is specified in the Mapbox Style object.                                                                                                                                                                                           |
+| `spriteImageUrl` | `string` \| `Request` \| `Promise`&lt;`string` \| `Request`>                                                                      | `undefined`          | Sprite image url for the sprite specified in the Mapbox Style object's `sprite` property. Only required if a `sprite` property is specified in the Mapbox Style object.                                                                                                                                                                                           |
 | `getFonts`       | (`arg0`: `string`\[], `arg1`: `string`) => `string`\[]                                                                            | `undefined`          | Function that receives a font stack and the url template from the GL style's `metadata['ol:webfonts']` property (if set) as arguments, and returns a (modified) font stack that is available. Font names are the names used in the Mapbox Style object. If not provided, the font stack will be used as-is. This function can also be used for loading web fonts. |
 | `getImage?`      | (`arg0`: `VectorLayer`&lt;`any`> \| `VectorTileLayer`, `arg1`: `string`) => `string` \| `HTMLCanvasElement` \| `HTMLImageElement` | `undefined`          | Function that returns an image or a URL for an image name. If the result is an HTMLImageElement, it must already be loaded. The layer can be used to call layer.changed() when the loading and processing of the image has finished. This function can be used for icons not in the sprite or to override sprite icons.                                           |
 | `...args`        | `any`                                                                                                                             | `undefined`          | -                                                                                                                                                                                                                                                                                                                                                                 |
@@ -1167,11 +1167,11 @@ as object, when they contain a relative sprite url, or sources referencing data 
 
 #### transformRequest
 
-• **transformRequest**: (`arg0`: `string`, `arg1`: [`ResourceType`](#ResourceType)) => `string` \| `void` \| `Request`
+• **transformRequest**: (`arg0`: `string`, `arg1`: [`ResourceType`](#ResourceType)) => `string` \| `void` \| `Request` \| `Promise`&lt;`string` \| `Request`>
 
 ##### Type declaration
 
-▸ (`arg0`, `arg1`): `string` \| `void` \| `Request`
+▸ (`arg0`, `arg1`): `string` \| `void` \| `Request` \| `Promise`&lt;`string` \| `Request`>
 
 Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
 the url, adding headers or setting credentials options. Called with the url and the resource
@@ -1187,7 +1187,7 @@ the original request will not be modified.
 
 ###### Returns
 
-`string` \| `void` \| `Request`
+`string` \| `void` \| `Request` \| `Promise`&lt;`string` \| `Request`>
 
 <a name="modulesinternal_md"></a>
 

--- a/src/apply.js
+++ b/src/apply.js
@@ -65,11 +65,11 @@ import {
 /**
  * @typedef {Object} Options
  * @property {string} [accessToken] Access token for 'mapbox://' urls.
- * @property {function(string, import("./util.js").ResourceType): (Request|string|void)} [transformRequest]
+ * @property {function(string, import("./util.js").ResourceType): (Request|string|Promise<Request|string>|void)} [transformRequest]
  * Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
  * the url, adding headers or setting credentials options. Called with the url and the resource
- * type as arguments, this function is supposed to return a `Request` or a url `string`. Without a return value,
- * the original request will not be modified.
+ * type as arguments, this function is supposed to return a `Request` or a url `string`, or a promise tehereof.
+ * Without a return value the original request will not be modified.
  * @property {string} [projection='EPSG:3857'] Only useful when working with non-standard projections.
  * Code of a projection registered with OpenLayers. All sources of the style must be provided in this
  * projection. The projection must also have a valid extent defined, which will be used to determine the
@@ -419,7 +419,10 @@ export function applyStyle(
                 const transformed =
                   options.transformRequest(spriteImageUrl, 'SpriteImage') ||
                   spriteImageUrl;
-                if (transformed instanceof Request) {
+                if (
+                  transformed instanceof Request ||
+                  transformed instanceof Promise
+                ) {
                   spriteImageUrl = transformed;
                 }
               }

--- a/test/MapboxVectorLayer.test.js
+++ b/test/MapboxVectorLayer.test.js
@@ -162,20 +162,28 @@ describe('ol/layer/MapboxVector', () => {
     afterEach(function () {
       window.fetch = originalFetch;
     });
-    it('applies correct access token', function () {
+    it('applies correct access token', function (done) {
       new MapboxVectorLayer({
         styleUrl: 'mapbox://styles/mapbox/streets-v7',
         accessToken: '123',
-      });
-      should(fetchUrl.url).eql(
-        'https://api.mapbox.com/styles/v1/mapbox/streets-v7?&access_token=123'
-      );
+      })
+        .getSource()
+        .once('change', () => {
+          should(fetchUrl.url).eql(
+            'https://api.mapbox.com/styles/v1/mapbox/streets-v7?&access_token=123'
+          );
+          done();
+        });
     });
-    it('applies correct access token from url', function () {
+    it('applies correct access token from url', function (done) {
       new MapboxVectorLayer({
         styleUrl: 'foo?key=123',
-      });
-      should(fetchUrl.url).eql(`${location.origin}/foo?key=123`);
+      })
+        .getSource()
+        .once('change', () => {
+          should(fetchUrl.url).eql(`${location.origin}/foo?key=123`);
+          done();
+        });
     });
   });
 });

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -236,12 +236,14 @@ describe('ol-mapbox-style', function () {
                 1,
                 map.getView().getProjection()
               );
-              window.fetch = originalFetch;
-              const url = new URL(requests[0].url);
-              const bbox = url.searchParams.get('bbox');
-              const extent = map.getView().calculateExtent();
-              should(bbox).be.equal(extent.join(','));
-              done();
+              source.once('change', () => {
+                window.fetch = originalFetch;
+                const url = new URL(requests[0].url);
+                const bbox = url.searchParams.get('bbox');
+                const extent = map.getView().calculateExtent();
+                should(bbox).be.equal(extent.join(','));
+                done();
+              });
             })
             .catch(done);
         });
@@ -340,12 +342,14 @@ describe('ol-mapbox-style', function () {
             1,
             get('EPSG:3857')
           );
-          window.fetch = originalFetch;
-          const url = new URL(requests[0].url);
-          should(url.searchParams.get('transformRequest')).be.equal('true');
-          should(source).be.instanceof(VectorSource);
-          should(layer.getStyle()).be.a.Function();
-          done();
+          source.once('change', () => {
+            window.fetch = originalFetch;
+            const url = new URL(requests[0].url);
+            should(url.searchParams.get('transformRequest')).be.equal('true');
+            should(source).be.instanceof(VectorSource);
+            should(layer.getStyle()).be.a.Function();
+            done();
+          });
         })
         .catch(done);
     });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -37,33 +37,38 @@ describe('util', function () {
     it('adds the request to the metadata for both pending and new requests', function (done) {
       const metadataNotPending = {};
       const metadataPending = {};
-      fetchResource(
-        'Sprite',
-        'my://resource',
-        {
-          transformRequest: function (url, resourceType) {
-            should(url).equal('my://resource');
-            should(resourceType).equal('Sprite');
-            return new Request('/fixtures/sprites.json');
+      Promise.all([
+        fetchResource(
+          'Sprite',
+          'my://resource',
+          {
+            transformRequest: function (url, resourceType) {
+              should(url).equal('my://resource');
+              should(resourceType).equal('Sprite');
+              return new Request('/fixtures/sprites.json');
+            },
           },
-        },
-        metadataNotPending
-      );
-      fetchResource(
-        'Sprite',
-        'my://resource',
-        {
-          transformRequest: function (url, resourceType) {
-            should(url).equal('my://resource');
-            should(resourceType).equal('Sprite');
-            return new Request('/fixtures/sprites.json');
+          metadataNotPending
+        ),
+        fetchResource(
+          'Sprite',
+          'my://resource',
+          {
+            transformRequest: function (url, resourceType) {
+              should(url).equal('my://resource');
+              should(resourceType).equal('Sprite');
+              return new Request('/fixtures/sprites.json');
+            },
           },
-        },
-        metadataPending
-      );
-      should('request' in metadataPending).true();
-      should(metadataPending.request).equal(metadataNotPending.request);
-      done();
+          metadataPending
+        ),
+      ])
+        .then(() => {
+          should('request' in metadataPending).true();
+          should(metadataPending.request).equal(metadataNotPending.request);
+          done();
+        })
+        .catch((err) => done(err));
     });
   });
   describe('getTileJson', function () {


### PR DESCRIPTION
This pull request enables `transformRequest()` to return a `Promise` resolving to a `Request` or url `string`, instead of just a `Request` or an `url` string. This allows users that need to add auth headers to obtain those headers asynchronously:
```js
transformRequest: async (url, type) => {
  return new Request(
    url,
    {
      headers: await getAuthHeaders()
    }
  );
}