### PR TITLE
Apply icon-size (scale) for imageElement icons

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -926,6 +926,7 @@ export function stylefunction(
                         rotateWithView: iconRotationAlignment === 'map',
                         displacement: displacement,
                         declutterMode: declutterMode,
+                        scale: iconSize,
                       };
                       if (typeof imageElement === 'string') {
                         // it is a src URL


### PR DESCRIPTION
This adds the missing scale property on Icon when using non-sprite images.