### PR TITLE
Handle fractional zooms for layer min/maxResolution properly

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -39,6 +39,7 @@ import {bbox as bboxStrategy} from 'ol/loadingstrategy.js';
 import {createXYZ} from 'ol/tilegrid.js';
 import {
   defaultResolutions,
+  defaultTileGrid,
   fetchResource,
   getFilterCache,
   getFunctionCache,
@@ -1221,18 +1222,20 @@ export function finalizeLayer(
           if (minZoom > 0 || sourceMinZoom > 0) {
             layer.setMaxResolution(
               Math.min(
-                defaultResolutions[minZoom],
+                defaultTileGrid.getResolution(minZoom),
                 tileGrid.getResolution(sourceMinZoom)
               ) + 1e-9
             );
           }
           if (maxZoom < 24) {
-            layer.setMinResolution(defaultResolutions[maxZoom] + 1e-9);
+            layer.setMinResolution(
+              defaultTileGrid.getResolution(maxZoom) + 1e-9
+            );
           }
         }
       } else {
         if (minZoom > 0) {
-          layer.setMaxResolution(defaultResolutions[minZoom] + 1e-9);
+          layer.setMaxResolution(defaultTileGrid.getResolution(minZoom) + 1e-9);
         }
       }
       if (

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,8 @@
+import TileGrid from 'ol/tilegrid/TileGrid.js';
 import TileState from 'ol/TileState.js';
 import {VectorTile} from 'ol';
 import {expandUrl} from 'ol/tileurlfunction.js';
+import {get as getProjection} from 'ol/proj.js';
 import {getUid} from 'ol/util.js';
 import {normalizeSourceUrl, normalizeStyleUrl} from './mapbox.js';
 import {toPromise} from 'ol/functions.js';
@@ -72,6 +74,11 @@ export const defaultResolutions = (function () {
   }
   return resolutions;
 })();
+
+export const defaultTileGrid = new TileGrid({
+  extent: getProjection('EPSG:3857').getExtent(),
+  resolutions: defaultResolutions,
+});
 
 /**
  * @param {number} width Width of the canvas.


### PR DESCRIPTION
This pull request fixes a problem where a layer minResolution or maxResolution will be set to NaN when the lowest or highest zoom of a Mapbox layer for an OpenLayer layer is a fractional zoom.