### PR TITLE
Add background as first layer

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -456,7 +456,9 @@ function setFirstBackground(mapOrLayer, glStyle, options) {
         return true;
       }
       if (mapOrLayer instanceof Map || mapOrLayer instanceof LayerGroup) {
-        mapOrLayer.getLayers().push(setupBackgroundLayer(layer, options, {}));
+        mapOrLayer
+          .getLayers()
+          .insertAt(0, setupBackgroundLayer(layer, options, {}));
         return true;
       }
     }


### PR DESCRIPTION
When `applyBackground()` is called on an existing map, the background layer will be added as last layer rather than first. This pull request fixes that.

Fixes #1040