### PR TITLE
tilegrid resolutions can use options

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -531,10 +531,9 @@ function sourceOptionsFromTileJSON(glSource, tileJSON, options) {
         : tileGrid.getOrigin(0),
       extent: extent || tileGrid.getExtent(),
       minZoom: minZoom,
-      resolutions: getTileResolutions(projection, tileJSON.tileSize).slice(
-        0,
-        maxZoom + 1
-      ),
+      resolutions:
+        options.resolutions ||
+        getTileResolutions(projection, tileJSON.tileSize).slice(0, maxZoom + 1),
       tileSize: tileGrid.getTileSize(0),
     }),
   };


### PR DESCRIPTION
Hi~ When I use `applyStyle` function with custom resolutions, I find the VectorTileSource tilegrid resolutions not use my custom. So I update this.