### PR TITLE
Allow default `line-color` when property not present

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -639,29 +639,30 @@ export function stylefunction(
           }
         }
         if (type != 1 && layer.type == 'line') {
-          color =
-            !('line-pattern' in paint) && 'line-color' in paint
-              ? colorWithOpacity(
-                  getValue(
-                    layer,
-                    'paint',
-                    'line-color',
-                    zoom,
-                    f,
-                    functionCache,
-                    featureState
-                  ),
-                  getValue(
-                    layer,
-                    'paint',
-                    'line-opacity',
-                    zoom,
-                    f,
-                    functionCache,
-                    featureState
-                  )
-                )
-              : undefined;
+          if (!('line-pattern' in paint)) {
+            color = colorWithOpacity(
+              getValue(
+                layer,
+                'paint',
+                'line-color',
+                zoom,
+                f,
+                functionCache,
+                featureState
+              ),
+              getValue(
+                layer,
+                'paint',
+                'line-opacity',
+                zoom,
+                f,
+                functionCache,
+                featureState
+              )
+            );
+          } else {
+            color = undefined;
+          }
           const width = getValue(
             layer,
             'paint',


### PR DESCRIPTION
Previously the `default` from the property spec for `line-color` was not being applied because of the clause `'line-color' in paint`

This PR fixes that, which means the following layer style will show a line (in line with maplibre/mapbox)

```json
{
    "id": "test",
    "type": "line",
    "source": "lines",
    "layout": {},
    "paint": {}
}
```