### PR TITLE
Allow `background-color` to use default from spec

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -558,17 +558,15 @@ function getBackgroundColor(glLayer, resolution, options, functionCache) {
     resolution,
     options.resolutions || defaultResolutions
   );
-  let bg, opacity;
-  if (paint['background-color'] !== undefined) {
-    bg = getValue(
-      background,
-      'paint',
-      'background-color',
-      zoom,
-      emptyObj,
-      functionCache
-    );
-  }
+  let opacity;
+  const bg = getValue(
+    background,
+    'paint',
+    'background-color',
+    zoom,
+    emptyObj,
+    functionCache
+  );
   if (paint['background-opacity'] !== undefined) {
     opacity = getValue(
       background,


### PR DESCRIPTION
This PR is a fix to use the default from the spec for the `background-color`. The following now results in a `#000000` background as per the spec.

```json
{
    "id": "background",
    "type": "background",
    "paint": {}
}
``` 