### PR TITLE
Added `raster-`(`hue-rotate`/`contrast`/`saturation`/`opacity`/`brightness-*`/) as operations

### DIFF
--- a/src/shaders.js
+++ b/src/shaders.js
@@ -275,8 +275,7 @@ export function raster(inputs, data) {
       shadeData[offset] = r;
       shadeData[offset + 1] = g;
       shadeData[offset + 2] = b;
-      shadeData[offset + 3] =
-        data.opacity !== undefined ? data.opacity * 255 : pixel[3];
+      shadeData[offset + 3] = pixel[3];
     }
   }
 


### PR DESCRIPTION
This PR adds the following styling rules

 - [`raster-hue-rotate`](https://docs.mapbox.com/style-spec/reference/layers/#paint-raster-raster-hue-rotate)
 - [`raster-contrast`](https://docs.mapbox.com/style-spec/reference/layers/#paint-raster-raster-contrast)
 - [`raster-saturation`](https://docs.mapbox.com/style-spec/reference/layers/#paint-raster-raster-saturation)
 - [`raster-brightness-min`](https://docs.mapbox.com/style-spec/reference/layers/#paint-raster-raster-brightness-min)
 - [`raster-brightness-max`](https://docs.mapbox.com/style-spec/reference/layers/#paint-raster-raster-brightness-max)

Missing: Tests for new `raster-*` operations.