### PR TITLE
Added support for `circle-translate`

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1111,6 +1111,16 @@ export function stylefunction(
               featureState
             )
           );
+
+          const circleTranslate = getValue(
+            layer,
+            'paint',
+            'circle-translate',
+            zoom,
+            f,
+            functionCache,
+            featureState
+          );
           const circleColor = colorWithOpacity(
             getValue(
               layer,
@@ -1147,11 +1157,17 @@ export function stylefunction(
             '.' +
             circleColor +
             '.' +
-            circleStrokeWidth;
+            circleStrokeWidth +
+            '.' +
+            circleTranslate[0] +
+            '.' +
+            circleTranslate[1];
+
           iconImg = iconImageCache[cache_key];
           if (!iconImg) {
             iconImg = new Circle({
               radius: circleRadius,
+              displacement: [circleTranslate[0], -circleTranslate[1]],
               stroke:
                 circleStrokeColor && circleStrokeWidth > 0
                   ? new Stroke({


### PR DESCRIPTION
Added support for `circle-translate`

Screenshot of OpenLayers on **left** and MapLibre (via Maputnik) on **right** 

![Screenshot from 2023-12-12 14-34-49](https://github.com/openlayers/ol-mapbox-style/assets/235915/80243b9b-5159-4f74-8d6d-d42aabc41bda)

With the following layers added to the style from <https://raw.githubusercontent.com/openlayers/ol-mapbox-style/dab4ad81d99d317e20e101228071de0f9745c801/examples/data/geojson-inline.json>

```json
[
    {
      "source": "points",
      "type": "circle",
      "id": "points1",
      "layout": {
      },
      "paint": {
      }
    },
    {
      "source": "points",
      "type": "circle",
      "id": "points2",
      "layout": {
      },
      "paint": {
        "circle-translate": [5, 5],
        "circle-color": "red"
      }
    },
    {
      "source": "points",
      "type": "circle",
      "id": "points3",
      "layout": {
      },
      "paint": {
        "circle-translate": [10, 10],
        "circle-color": "green"
      }
    },
    {
      "source": "points",
      "type": "circle",
      "id": "points4",
      "layout": {
      },
      "paint": {
        "circle-translate": [15, 15],
        "circle-color": "blue"
      }
    }
]
```