### PR TITLE
Don't throw on unsupported `heatmap` layer type instead show helpful debug info

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -1030,9 +1030,7 @@ function processStyle(glStyle, mapOrGroup, styleUrl, options) {
     if (type == 'heatmap') {
       //FIXME Unsupported layer type
       // eslint-disable-next-line no-console
-      console.debug(
-        `[ol-mapbox-style] layers[${i}].type "${type}" not supported`
-      );
+      console.debug(`layers[${i}].type "${type}" not supported`);
       continue;
     } else {
       id = glLayer.source || getSourceIdByRef(glLayers, glLayer.ref);

--- a/src/apply.js
+++ b/src/apply.js
@@ -1029,7 +1029,11 @@ function processStyle(glStyle, mapOrGroup, styleUrl, options) {
     const type = glLayer.type;
     if (type == 'heatmap') {
       //FIXME Unsupported layer type
-      throw new Error(`${type} layers are not supported`);
+      // eslint-disable-next-line no-console
+      console.debug(
+        `[ol-mapbox-style] layers[${i}].type "${type}" not supported`
+      );
+      continue;
     } else {
       id = glLayer.source || getSourceIdByRef(glLayers, glLayer.ref);
       // this technique assumes gl layers will be in a particular order


### PR DESCRIPTION
Previous to this change a style with a `heatmap` layer type would "throw" crashing the app. We now just `console.debug` with

```
[ol-mapbox-style] layers[1].type "heatmap" not supported
```

Reasons for `console.debug` instead of console warn/log, is that `console.debug` doesn't show up in the console by default. You have to enable verbose logging in the web inspector.

This also has the same behaviour as other unsupported styling rules, for example [icon-pitch-alignment](https://docs.mapbox.com/style-spec/reference/layers/#layout-symbol-icon-pitch-alignment)  