### PR TITLE
Switch to basic canvas operations to fix circle stroke position

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1170,6 +1170,10 @@ export function stylefunction(
             '.' +
             circleStrokeWidth +
             '.' +
+            circleTranslate[0] +
+            '.' +
+            circleTranslate[1] +
+            '.' +
             circleBlur;
           text = style.getText();
           style.setText(undefined);


### PR DESCRIPTION
This PR switches over to basic canvas rendering for circles to fix stroke position. Previously the stroke was positioned mid way along the line like so

**Before**
![Screenshot from 2023-12-13 10-48-07](https://github.com/openlayers/ol-mapbox-style/assets/235915/bbf8e421-9d18-423a-825b-02b8ae5bdf57)

**After**
![Screenshot from 2023-12-13 10-48-42](https://github.com/openlayers/ol-mapbox-style/assets/235915/0a4288b3-c2b4-4e7f-9a64-f65742a45ae2)

This also means that circles are visually the correct size. You can see the issue in these before screenshots from my (modified) [spec helper](https://maparatus.github.io/ol-mapbox-style-spec/), you can see that the total radius of the circle is incorrect because of the circle stroke sitting mid-way on the circle fill (rather than outside)

![Screenshot from 2023-12-13 10-49-47](https://github.com/openlayers/ol-mapbox-style/assets/235915/b6b7c267-221c-4e6b-83e1-e83980fac625)

Because we're now using basic canvas operations I also added support for `circle-blur`

<img width="300" src="https://github.com/openlayers/ol-mapbox-style/assets/235915/dc0128e6-3fb6-40ee-820e-a412e5d78dc9" />

@ahocevar if you're happy with the approach, let me know and I'll give it another good test prior to making it ready for merge.