### PR TITLE
Added `*-sort-key` support

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -28,6 +28,7 @@ import {
   stylefunction as applyStylefunction,
   getValue,
   styleFunctionArgs,
+  types,
 } from './stylefunction.js';
 import {bbox as bboxStrategy} from 'ol/loadingstrategy.js';
 import {createXYZ} from 'ol/tilegrid.js';
@@ -50,6 +51,7 @@ import {
 } from 'ol/proj.js';
 import {getFonts} from './text.js';
 import {getTopLeft} from 'ol/extent.js';
+import {getUid} from 'ol';
 import {hillshade} from './shaders.js';
 import {
   normalizeSourceUrl,
@@ -904,6 +906,37 @@ export function setupLayer(glStyle, styleUrl, glLayer, options) {
     layer.on('prerender', prerenderRasterLayer(glLayer, layer, functionCache));
   } else if (glSource.type == 'geojson') {
     layer = setupGeoJSONLayer(glSource, styleUrl, options);
+    layer.setRenderOrder((f1, f2) => {
+      const getRenderOrder = (feature) => {
+        if (['fill', 'line', 'symbol', 'circle'].includes(glLayer.type)) {
+          const f = {
+            id: feature.getId(),
+            type: types[feature.getGeometry().getType()],
+            properties: feature.getProperties(),
+          };
+
+          const featureState = layer.get('mapbox-featurestate')[
+            feature.getId()
+          ];
+
+          const sortOrder = getValue(
+            glLayer,
+            'layout',
+            `${glLayer.type}-sort-key`,
+            null,
+            f,
+            functionCache,
+            featureState
+          );
+          if (sortOrder === null) {
+            return parseInt(getUid(feature), 10);
+          }
+          return sortOrder;
+        }
+      };
+
+      return getRenderOrder(f1) - getRenderOrder(f2);
+    });
   } else if (glSource.type == 'raster-dem' && glLayer.type == 'hillshade') {
     const hillshadeLayer = setupHillshadeLayer(glSource, styleUrl, options);
     layer = hillshadeLayer;

--- a/src/apply.js
+++ b/src/apply.js
@@ -933,6 +933,7 @@ export function setupLayer(glStyle, styleUrl, glLayer, options) {
           }
           return sortOrder;
         }
+        return parseInt(getUid(feature), 10);
       };
 
       return getRenderOrder(f1) - getRenderOrder(f2);

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1093,7 +1093,7 @@ export function stylefunction(
                     getValue(
                       layer,
                       'layout',
-                      'line-sort-key',
+                      'symbol-sort-key',
                       zoom,
                       f,
                       functionCache,

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -21,7 +21,6 @@ import mb2css from 'mapbox-to-css-font';
 import spec from '@mapbox/mapbox-gl-style-spec/reference/v8.json';
 import {applyLetterSpacing, wrapText} from './text.js';
 import {
-  calcSortIndex,
   clearFunctionCache,
   createCanvas,
   defaultResolutions,
@@ -46,7 +45,7 @@ import {isFunction} from '@mapbox/mapbox-gl-style-spec/function/index.js';
  * @typedef {import('./util.js').ResourceType} ResourceType
  */
 
-const types = {
+export const types = {
   'Point': 1,
   'MultiPoint': 1,
   'LineString': 2,
@@ -520,22 +519,6 @@ export function stylefunction(
             featureState
           );
 
-          let zIndex = index;
-          if (layer.type === 'fill') {
-            zIndex = calcSortIndex(
-              index,
-              getValue(
-                layer,
-                'layout',
-                'fill-sort-key',
-                zoom,
-                f,
-                functionCache,
-                featureState
-              )
-            );
-          }
-
           if (layer.type + '-pattern' in paint) {
             const fillIcon = getValue(
               layer,
@@ -566,7 +549,7 @@ export function stylefunction(
                   styles[stylesLength] = style;
                 }
                 fill = style.getFill();
-                style.setZIndex(zIndex);
+                style.setZIndex(index);
                 const icon_cache_key = icon + '.' + opacity;
                 let pattern = patternCache[icon_cache_key];
                 if (!pattern) {
@@ -652,7 +635,8 @@ export function stylefunction(
                 stroke.setColor(strokeColor);
                 stroke.setWidth(0.5);
               }
-              style.setZIndex(zIndex);
+
+              style.setZIndex(index);
             }
           }
         }
@@ -741,19 +725,6 @@ export function stylefunction(
             stroke.setColor(color);
             stroke.setWidth(width);
 
-            const zIndex = calcSortIndex(
-              index,
-              getValue(
-                layer,
-                'layout',
-                'line-sort-key',
-                zoom,
-                f,
-                functionCache,
-                featureState
-              )
-            );
-
             stroke.setLineDash(
               paint['line-dasharray']
                 ? getValue(
@@ -769,7 +740,7 @@ export function stylefunction(
                   })
                 : null
             );
-            style.setZIndex(zIndex);
+            style.setZIndex(index);
           }
         }
 
@@ -1088,23 +1059,11 @@ export function stylefunction(
                     ]
                   );
 
-                  const zIndex = calcSortIndex(
-                    index,
-                    getValue(
-                      layer,
-                      'layout',
-                      'symbol-sort-key',
-                      zoom,
-                      f,
-                      functionCache,
-                      featureState
-                    )
-                  );
-
                   style.setImage(iconImg);
                   text = style.getText();
                   style.setText(undefined);
-                  style.setZIndex(zIndex);
+
+                  style.setZIndex(index);
                   hasImage = true;
                   skipLabel = false;
                 }
@@ -1578,19 +1537,6 @@ export function stylefunction(
             opacity
           );
 
-          const zIndex = calcSortIndex(
-            index,
-            getValue(
-              layer,
-              'layout',
-              'symbol-sort-key',
-              zoom,
-              f,
-              functionCache,
-              featureState
-            )
-          );
-
           if (haloColor) {
             textHalo.setColor(haloColor);
             // spec here : https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-text-halo-width
@@ -1621,7 +1567,7 @@ export function stylefunction(
             padding[2] = textPadding;
             padding[3] = textPadding;
           }
-          style.setZIndex(zIndex);
+          style.setZIndex(index);
         }
       }
     }

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -21,6 +21,7 @@ import mb2css from 'mapbox-to-css-font';
 import spec from '@mapbox/mapbox-gl-style-spec/reference/v8.json';
 import {applyLetterSpacing, wrapText} from './text.js';
 import {
+  calcSortIndex,
   clearFunctionCache,
   createCanvas,
   defaultResolutions,
@@ -518,6 +519,20 @@ export function stylefunction(
             functionCache,
             featureState
           );
+
+          const zIndex = calcSortIndex(
+            index,
+            getValue(
+              layer,
+              'layout',
+              layer.type + '-sort-key',
+              zoom,
+              f,
+              functionCache,
+              featureState
+            )
+          );
+
           if (layer.type + '-pattern' in paint) {
             const fillIcon = getValue(
               layer,
@@ -548,7 +563,7 @@ export function stylefunction(
                   styles[stylesLength] = style;
                 }
                 fill = style.getFill();
-                style.setZIndex(index);
+                style.setZIndex(zIndex);
                 const icon_cache_key = icon + '.' + opacity;
                 let pattern = patternCache[icon_cache_key];
                 if (!pattern) {
@@ -634,7 +649,7 @@ export function stylefunction(
                 stroke.setColor(strokeColor);
                 stroke.setWidth(0.5);
               }
-              style.setZIndex(index);
+              style.setZIndex(zIndex);
             }
           }
         }
@@ -722,6 +737,20 @@ export function stylefunction(
             );
             stroke.setColor(color);
             stroke.setWidth(width);
+
+            const zIndex = calcSortIndex(
+              index,
+              getValue(
+                layer,
+                'layout',
+                'line-sort-key',
+                zoom,
+                f,
+                functionCache,
+                featureState
+              )
+            );
+
             stroke.setLineDash(
               paint['line-dasharray']
                 ? getValue(
@@ -737,7 +766,7 @@ export function stylefunction(
                   })
                 : null
             );
-            style.setZIndex(index);
+            style.setZIndex(zIndex);
           }
         }
 
@@ -1055,10 +1084,24 @@ export function stylefunction(
                       )
                     ]
                   );
+
+                  const zIndex = calcSortIndex(
+                    index,
+                    getValue(
+                      layer,
+                      'layout',
+                      'line-sort-key',
+                      zoom,
+                      f,
+                      functionCache,
+                      featureState
+                    )
+                  );
+
                   style.setImage(iconImg);
                   text = style.getText();
                   style.setText(undefined);
-                  style.setZIndex(index);
+                  style.setZIndex(zIndex);
                   hasImage = true;
                   skipLabel = false;
                 }
@@ -1531,6 +1574,20 @@ export function stylefunction(
             ),
             opacity
           );
+
+          const zIndex = calcSortIndex(
+            index,
+            getValue(
+              layer,
+              'layout',
+              'symbol-sort-key',
+              zoom,
+              f,
+              functionCache,
+              featureState
+            )
+          );
+
           if (haloColor) {
             textHalo.setColor(haloColor);
             // spec here : https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-text-halo-width
@@ -1561,7 +1618,7 @@ export function stylefunction(
             padding[2] = textPadding;
             padding[3] = textPadding;
           }
-          style.setZIndex(index);
+          style.setZIndex(zIndex);
         }
       }
     }

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -518,7 +518,6 @@ export function stylefunction(
             functionCache,
             featureState
           );
-
           if (layer.type + '-pattern' in paint) {
             const fillIcon = getValue(
               layer,
@@ -635,7 +634,6 @@ export function stylefunction(
                 stroke.setColor(strokeColor);
                 stroke.setWidth(0.5);
               }
-
               style.setZIndex(index);
             }
           }
@@ -724,7 +722,6 @@ export function stylefunction(
             );
             stroke.setColor(color);
             stroke.setWidth(width);
-
             stroke.setLineDash(
               paint['line-dasharray']
                 ? getValue(
@@ -1058,11 +1055,9 @@ export function stylefunction(
                       )
                     ]
                   );
-
                   style.setImage(iconImg);
                   text = style.getText();
                   style.setText(undefined);
-
                   style.setZIndex(index);
                   hasImage = true;
                   skipLabel = false;
@@ -1536,7 +1531,6 @@ export function stylefunction(
             ),
             opacity
           );
-
           if (haloColor) {
             textHalo.setColor(haloColor);
             // spec here : https://docs.mapbox.com/mapbox-gl-js/style-spec/#paint-symbol-text-halo-width

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -520,18 +520,21 @@ export function stylefunction(
             featureState
           );
 
-          const zIndex = calcSortIndex(
-            index,
-            getValue(
-              layer,
-              'layout',
-              layer.type + '-sort-key',
-              zoom,
-              f,
-              functionCache,
-              featureState
-            )
-          );
+          let zIndex = index;
+          if (layer.type === 'fill') {
+            zIndex = calcSortIndex(
+              index,
+              getValue(
+                layer,
+                'layout',
+                'fill-sort-key',
+                zoom,
+                f,
+                functionCache,
+                featureState
+              )
+            );
+          }
 
           if (layer.type + '-pattern' in paint) {
             const fillIcon = getValue(

--- a/src/util.js
+++ b/src/util.js
@@ -400,8 +400,9 @@ export function drawSDF(image, area, color) {
 }
 
 /**
- * @param {number} index
- * @param {number} sortIndex
+ * @param {number} index render index of layer
+ * @param {number} sortIndex the sort index within that layer
+ * @return {number} newly calculated index
  */
 export function calcSortIndex(index, sortIndex) {
   return index + (sortIndex === undefined ? 0 : sortIndex) * 0.00000000001;

--- a/src/util.js
+++ b/src/util.js
@@ -403,12 +403,3 @@ export function drawSDF(image, area, color) {
  * @typedef {import("./apply.js").Options} Options
  * @private
  */
-
-/**
- * @param {number} index render index of layer
- * @param {number} sortIndex the sort index within that layer
- * @return {number} newly calculated index
- */
-export function calcSortIndex(index, sortIndex) {
-  return index + (sortIndex === undefined ? 0 : sortIndex) * 0.00000000001;
-}

--- a/src/util.js
+++ b/src/util.js
@@ -400,6 +400,9 @@ export function drawSDF(image, area, color) {
 }
 
 /**
- * @typedef {import("./apply.js").Options} Options
- * @private
+ * @param {number} index
+ * @param {number} sortIndex
  */
+export function calcSortIndex(index, sortIndex) {
+  return index + (sortIndex === undefined ? 0 : sortIndex) * 0.00000000001;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -400,6 +400,11 @@ export function drawSDF(image, area, color) {
 }
 
 /**
+ * @typedef {import("./apply.js").Options} Options
+ * @private
+ */
+
+/**
  * @param {number} index render index of layer
  * @param {number} sortIndex the sort index within that layer
  * @return {number} newly calculated index


### PR DESCRIPTION
This PR implements the `*-sort-key` rules.

Here is an example with the following layer rule, where `#ff0000` fills have a higher sort order that `#0000ff` fills. 

```json
{
  "id": "test",
  "type": "fill",
  "source": "polygons",
  "layout": {
    "fill-sort-key": [
      "get",
      "zIndex"
    ]
  },
  "paint": {
    "fill-color": [
      "get",
      "color"
    ]
  }
}
```

Previously this resulted in 

![Screenshot from 2023-12-14 16-20-25](https://github.com/openlayers/ol-mapbox-style/assets/235915/cb16eb08-d6a8-4078-a659-ad16f42f2940)

Now we get the correct result. 

![Screenshot from 2023-12-14 16-21-24](https://github.com/openlayers/ol-mapbox-style/assets/235915/35176fde-fab2-4d15-af3c-9c0b0773da57)
