### PR TITLE
Compute value of text-transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ parameter of the style url.
 
 #### background
 
-• **background**: `string` \| `false` \| (`arg0`: `number`) => `string`
+• **background**: `false` \| `BackgroundColor`
 
 Background color for the layer.
 If not specified, the background from the Mapbox style object will be used. Set to `false` to prevent

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1343,7 +1343,15 @@ export function stylefunction(
             );
           }
           text = style.getText();
-          const textTransform = layout['text-transform'];
+          const textTransform = getValue(
+            layer,
+            'layout',
+            'text-transform',
+            zoom,
+            f,
+            functionCache,
+            featureState,
+          );
           if (textTransform == 'uppercase') {
             label = Array.isArray(label)
               ? label.map((t, i) => (i % 2 ? t : t.toUpperCase()))


### PR DESCRIPTION
`text-transform` appears to be the last remaining property that does not work for context computed values. This pull request fixes that.