### PR TITLE
Make minZoom inclusive by zoom instead of resolution

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -319,9 +319,9 @@ export function applyStyle(
               ) {
                 layer.setMaxResolution(
                   getResolutionForZoom(
-                    tileGrid.getMinZoom(),
-                    defaultResolutions,
-                  ) + 1e-15,
+                    Math.max(0, tileGrid.getMinZoom() - 1e-12),
+                    tileGrid.getResolutions(),
+                  ),
                 );
               }
             });
@@ -1237,9 +1237,15 @@ export function finalizeLayer(
           if (minZoom > 0 || sourceMinZoom > 0) {
             layer.setMaxResolution(
               Math.min(
-                getResolutionForZoom(minZoom, defaultResolutions),
-                tileGrid.getResolution(sourceMinZoom),
-              ) + 1e-15,
+                getResolutionForZoom(
+                  Math.max(0, minZoom - 1e-12),
+                  defaultResolutions,
+                ),
+                getResolutionForZoom(
+                  Math.max(0, sourceMinZoom - 1e-12),
+                  tileGrid.getResolutions(),
+                ),
+              ),
             );
           }
           if (maxZoom < 24) {
@@ -1251,7 +1257,10 @@ export function finalizeLayer(
       } else {
         if (minZoom > 0) {
           layer.setMaxResolution(
-            getResolutionForZoom(minZoom, defaultResolutions) + 1e-15,
+            getResolutionForZoom(
+              Math.max(0, minZoom - 1e-12),
+              defaultResolutions,
+            ),
           );
         }
       }

--- a/test/MapboxVectorLayer.test.js
+++ b/test/MapboxVectorLayer.test.js
@@ -2,6 +2,7 @@ import Map from 'ol/Map.js';
 import MapboxVectorLayer from '../src/MapboxVectorLayer.js';
 import View from 'ol/View.js';
 import should from 'should';
+import {defaultResolutions, getZoomForResolution} from '../src/util.js';
 import {unByKey} from 'ol/Observable.js';
 
 describe('ol/layer/MapboxVector', () => {
@@ -49,6 +50,7 @@ describe('ol/layer/MapboxVector', () => {
             'foo': {
               tiles: ['/spec/ol/data/{z}-{x}-{y}.vector.pbf'],
               type: 'vector',
+              tileSize: 256,
               minzoom: 6,
             },
           },
@@ -82,9 +84,10 @@ describe('ol/layer/MapboxVector', () => {
       source.on('change', function onchange() {
         if (source.getState() === 'ready') {
           source.un('change', onchange);
-          should(layer.getMaxResolution()).eql(
-            source.getTileGrid().getResolution(6),
-          );
+          should(
+            getZoomForResolution(layer.getMaxResolution(), defaultResolutions) +
+              1e-12,
+          ).eql(5);
           done();
         }
       });

--- a/test/apply.test.js
+++ b/test/apply.test.js
@@ -27,7 +27,7 @@ import {
   setFeatureState,
 } from '../src/index.js';
 import {containsExtent} from 'ol/extent.js';
-import {defaultResolutions} from '../src/util.js';
+import {defaultResolutions, getZoomForResolution} from '../src/util.js';
 delete brightV9.sprite;
 
 describe('ol-mapbox-style', function () {
@@ -699,9 +699,12 @@ describe('ol-mapbox-style', function () {
         context.sources.states.minzoom = 10;
         apply(target, context)
           .then(function (map) {
-            should(map.getLayers().item(0).getMaxResolution()).eql(
-              defaultResolutions[9] + 1e-15,
-            );
+            should(
+              getZoomForResolution(
+                map.getLayers().item(0).getMaxResolution(),
+                defaultResolutions,
+              ) + 1e-12,
+            ).eql(9);
             done();
           })
           .catch(function (err) {
@@ -714,9 +717,12 @@ describe('ol-mapbox-style', function () {
         context.layers[0].maxzoom = 12;
         apply(target, context)
           .then(function (map) {
-            should(map.getLayers().item(0).getMaxResolution()).eql(
-              defaultResolutions[10] + 1e-15,
-            );
+            should(
+              getZoomForResolution(
+                map.getLayers().item(0).getMaxResolution(),
+                defaultResolutions,
+              ) + 1e-12,
+            ).eql(10);
             should(map.getLayers().item(0).getMinResolution()).eql(
               defaultResolutions[12],
             );
@@ -755,7 +761,12 @@ describe('ol-mapbox-style', function () {
         apply(target, './fixtures/geojson-wfs.json')
           .then(function (map) {
             const layer = map.getAllLayers()[1];
-            should(layer.getMaxResolution()).eql(defaultResolutions[5] + 1e-15);
+            should(
+              getZoomForResolution(
+                layer.getMaxResolution(),
+                defaultResolutions,
+              ) + 1e-12,
+            ).eql(5);
             done();
           })
           .catch(function (err) {
@@ -881,9 +892,12 @@ describe('ol-mapbox-style', function () {
         context.sources.osm.minzoom = 8;
         apply(target, context)
           .then(function (map) {
-            should(map.getLayers().item(0).getMaxResolution()).eql(
-              defaultResolutions[8] + 1e-15,
-            );
+            should(
+              getZoomForResolution(
+                map.getLayers().item(0).getMaxResolution(),
+                defaultResolutions,
+              ) + 1e-12,
+            ).eql(8);
             done();
           })
           .catch(function (err) {
@@ -900,9 +914,12 @@ describe('ol-mapbox-style', function () {
         };
         apply(target, context)
           .then(function (map) {
-            should(map.getLayers().item(0).getMaxResolution()).eql(
-              defaultResolutions[8] + 1e-15,
-            );
+            should(
+              getZoomForResolution(
+                map.getLayers().item(0).getMaxResolution(),
+                defaultResolutions,
+              ) + 1e-12,
+            ).eql(8);
             done();
           })
           .catch(function (err) {
@@ -913,9 +930,12 @@ describe('ol-mapbox-style', function () {
       it('respects layer minzoom and maxzoom', function (done) {
         apply(target, context)
           .then(function (map) {
-            should(map.getLayers().item(0).getMaxResolution()).eql(
-              defaultResolutions[7] + 1e-15,
-            );
+            should(
+              getZoomForResolution(
+                map.getLayers().item(0).getMaxResolution(),
+                defaultResolutions,
+              ) + 1e-12,
+            ).eql(7);
             should(map.getLayers().item(0).getMinResolution()).eql(
               defaultResolutions[23],
             );

--- a/test/applyStyle.test.js
+++ b/test/applyStyle.test.js
@@ -15,6 +15,7 @@ import styleMissingSprite from './fixtures/style-missing-sprite.json';
 
 import VectorSource from 'ol/source/Vector.js';
 import {apply, applyStyle} from '../src/apply.js';
+import {defaultResolutions, getZoomForResolution} from '../src/util.js';
 import {get} from 'ol/proj.js';
 
 describe('applyStyle with source creation', function () {
@@ -353,9 +354,10 @@ describe('maxResolution', function () {
     const layer = new VectorTileLayer();
     applyStyle(layer, glStyle)
       .then(function () {
-        should(layer.getMaxResolution()).equal(
-          layer.getSource().getTileGrid().getResolution(6) - 1e-15,
-        );
+        should(
+          getZoomForResolution(layer.getMaxResolution(), defaultResolutions) +
+            1e-12,
+        ).eql(6);
         done();
       })
       .catch(function (e) {


### PR DESCRIPTION
This pull request fixes a regression introduced by #1121, with the smaller adjustments for `maxResolution` to avoid glitches with projections that have small resolution differences between zooms. To avoid these glitches, instead of adjusting the resolution to make `minZoom` inclusive, we now adjust the `minZoom` directly.