### PR TITLE
Remove polyfill io

### DIFF
--- a/examples/_template.html
+++ b/examples/_template.html
@@ -18,5 +18,4 @@
 </head>
 <body>
   <div id="map"></div>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=default,fetch,String.prototype.startsWith"></script>
 </body>


### PR DESCRIPTION
Because of security issues outlined in <https://dev.to/snyk/polyfill-supply-chain-attack-embeds-malware-in-javascript-cdn-assets-55d6>

Removed because no longer required, browser support is good enough now