### PR TITLE
more precise angle computation

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -832,14 +832,15 @@ export function stylefunction(
                         const x2 = coordinates[i + stride];
                         const y2 = coordinates[i + stride + 1];
                         const minX = Math.min(x1, x2);
-                        const minY = Math.min(y1, y2);
                         const maxX = Math.max(x1, x2);
-                        const maxY = Math.max(y1, y2);
                         const xM = midpoint[0];
                         const yM = midpoint[1];
+                        const dotProduct =
+                          (y2 - y1) * (xM - x1) - (x2 - x1) * (yM - y1);
                         if (
-                          Math.abs((y2-y1)*(xM-x1) - (x2-x1)*(yM-y1))<0.001 //midpoint is aligned with the segment
-                          && xM<=maxX && xM>=minX
+                          Math.abs(dotProduct) < 0.001 && //midpoint is aligned with the segment
+                          xM <= maxX &&
+                          xM >= minX //midpoint is on the segment and not outside it
                         ) {
                           placementAngle = Math.atan2(y1 - y2, x2 - x1);
                           break;

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -835,11 +835,11 @@ export function stylefunction(
                         const minY = Math.min(y1, y2);
                         const maxX = Math.max(x1, x2);
                         const maxY = Math.max(y1, y2);
+                        const xM = midpoint[0];
+                        const yM = midpoint[1];
                         if (
-                          midpoint[0] >= minX &&
-                          midpoint[0] <= maxX &&
-                          midpoint[1] >= minY &&
-                          midpoint[1] <= maxY
+                          Math.abs((y2-y1)*(xM-x1) - (x2-x1)*(yM-y1))<0.001 //midpoint is aligned with the segment
+                          && xM<=maxX && xM>=minX
                         ) {
                           placementAngle = Math.atan2(y1 - y2, x2 - x1);
                           break;


### PR DESCRIPTION
Currently, when using `"symbol-placement": "line"` and `"icon-rotation-alignment": "map"`, the angle of the icon is computed in ol-mapbox-style, as we know the location of the icon placement but not the corresponding line segment information. So the computation first tries to determine on which line segment the icon is located, then computes the slope of this segment and uses that as the rotation of the icon.

However, the algorithm used to determine on which segment is the icon is too simplistic: it simply takes the first segment for which the icon is inside the bounding box. However, there is no guarantee that this segment is the correct one and it is quite easy to construct a counter-example giving a wrong rotation angle: 
![image](https://github.com/user-attachments/assets/7aee44cc-9411-486b-a746-93dd968f993e) 

while it should be 

![image](https://github.com/user-attachments/assets/6995d7bb-78e3-44db-9723-2305386089d0)


This pull request proposes to replace this bounding box by a more precise comparison. I used to 0.001 tolerance to avoid dealing with potential floating point unpleasantness, I don't know if it is the ideal value but it is anyway much more precise than the current version.