### PR TITLE
Use the new keepUpright parameter in OpenLayers

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1402,6 +1402,16 @@ export function stylefunction(
               ),
             ),
           );
+          const keepUpright = getValue(
+            layer,
+            'layout',
+            'text-keep-upright',
+            zoom,
+            f,
+            functionCache,
+            featureState,
+          );
+          text.setKeepUpright(keepUpright);
           const textAnchor = getValue(
             layer,
             'layout',

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1402,16 +1402,18 @@ export function stylefunction(
               ),
             ),
           );
-          const keepUpright = getValue(
-            layer,
-            'layout',
-            'text-keep-upright',
-            zoom,
-            f,
-            functionCache,
-            featureState,
-          );
-          text.setKeepUpright(keepUpright);
+          if (typeof text.setKeepUpright === 'function') {
+            const keepUpright = getValue(
+              layer,
+              'layout',
+              'text-keep-upright',
+              zoom,
+              f,
+              functionCache,
+              featureState,
+            );
+            text.setKeepUpright(keepUpright);
+          }
           const textAnchor = getValue(
             layer,
             'layout',


### PR DESCRIPTION
Until now, the `text-keep-upright` parameter in the Mapbox Style specification was ignored, as OpenLayers was automatically keeping the labels upright and did not expose an option to control it. Now that the `keepUpright` parameter is available on `ol/style/Text`, this PR uses it to cover `text-keep-upright`.

This is a follow-up to #1206 now that the cleaner solution is available.