### PR TITLE
Add types for exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./src/index.js",
-      "require": "./dist/olms.js"
+      "require": "./dist/olms.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "repository": {


### PR DESCRIPTION
This pull request points to the types for the exports, because we no longer have an ESM bundle since #940.