### PR TITLE
Accept Response and Promise<Response> as transformRequest return

### DIFF
--- a/examples/pmtiles.js
+++ b/examples/pmtiles.js
@@ -1,7 +1,7 @@
 import 'ol/ol.css';
 import {apply} from 'ol-mapbox-style';
-import {register as registerPMTiles} from 'pmtiles-protocol';
+import {fetch} from 'pmtiles-protocol';
 
-registerPMTiles();
-
-apply('map', 'data/protomaps-dark-style.json');
+apply('map', 'data/protomaps-dark-style.json', {
+  transformRequest: (url) => fetch(url),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "mini-css-extract-plugin": "^2.4.4",
         "mocha": "^11.1.0",
         "nanoassert": "^2.0.0",
-        "pmtiles-protocol": "^1.0.1",
+        "pmtiles-protocol": "^1.0.5",
         "proj4": "^2.15.0",
         "puppeteer": "^23.10.4",
         "rollup": "^2.70.2",
@@ -7938,9 +7938,9 @@
       }
     },
     "node_modules/pmtiles-protocol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pmtiles-protocol/-/pmtiles-protocol-1.0.4.tgz",
-      "integrity": "sha512-V+cs31pZ/ziZP9n2PHAZmnyfRK5VQOSBJgOuutQ11rnTpaEfIeDP56qFTe0MPb0RzpwZhZHYs6Kn8fk9Q5Mp3Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pmtiles-protocol/-/pmtiles-protocol-1.0.5.tgz",
+      "integrity": "sha512-4S1oqZTES/Emvw7HFfB/uRUOflf7wQ3Qb8vqiYjQn1vOIS26HV/cCfd9iU6Srod9XGAtSGV7j4qw+My8IxUGFw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "mini-css-extract-plugin": "^2.4.4",
     "mocha": "^11.1.0",
     "nanoassert": "^2.0.0",
-    "pmtiles-protocol": "^1.0.1",
+    "pmtiles-protocol": "^1.0.5",
     "proj4": "^2.15.0",
     "puppeteer": "^23.10.4",
     "rollup": "^2.70.2",

--- a/src/apply.js
+++ b/src/apply.js
@@ -66,10 +66,10 @@ import {
 /**
  * @typedef {Object} Options
  * @property {string} [accessToken] Access token for 'mapbox://' urls.
- * @property {function(string, import("./util.js").ResourceType): (Request|string|Promise<Request|string>|void)} [transformRequest]
+ * @property {function(string, import("./util.js").ResourceType): (Request|string|Response|Promise<Request|string|Response>|void)} [transformRequest]
  * Function for controlling how `ol-mapbox-style` fetches resources. Can be used for modifying
  * the url, adding headers or setting credentials options. Called with the url and the resource
- * type as arguments, this function is supposed to return a `Request` or a url `string`, or a promise tehereof.
+ * type as arguments, this function is supposed to return a `Request`, a url `string` or a `Response`, or a promise tehereof.
  * Without a return value the original request will not be modified.
  * @property {string} [projection='EPSG:3857'] Only useful when working with non-standard projections.
  * Code of a projection registered with OpenLayers. All sources of the style must be provided in this

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -69,7 +69,7 @@ const mapboxSubdomains = ['a', 'b', 'c', 'd'];
  * @private
  */
 export function normalizeSourceUrl(url, token, tokenParam, styleUrl) {
-  const urlObject = new URL(url, styleUrl);
+  const urlObject = new URL(url, styleUrl || location.href);
   const mapboxPath = getMapboxPath(url);
   if (!mapboxPath) {
     if (!token) {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -64,7 +64,7 @@ describe('util', function () {
         ),
       ])
         .then(() => {
-          should('request' in metadataPending).true();
+          should('url' in metadataPending).true();
           should(metadataPending.request).equal(metadataNotPending.request);
           done();
         })


### PR DESCRIPTION
This pull request adds a huge improvement to the `transformRequest()` option: the function may now also return a Response or a Promise resolving to a Response. This means: no more Object URLs for anything that can be `fetch`ed! The modified `pmtiles.js` example shows how to make use of it.