### PR TITLE
quick fix for openlayers/ol-mapbox-style#1233

### DIFF
--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -1321,6 +1321,10 @@ export function stylefunction(
                 return acc;
               }, []);
             }
+            // omit label until OL supports rich text with line placement (openlayers/openlayers#16497)
+            if (typeof label === 'object' && "symbol-placement" in layout && layout["symbol-placement"] == "line") {
+              label = null;
+            }
           } else {
             label = fromTemplate(textField, properties).trim();
           }


### PR DESCRIPTION
This suppresses the non-printable labels, e.g. 

```
[ "", 'normal 400 12px/1.2 "Noto Sans"', "\n", "", "", 'normal 400 12px/1.2 "Noto Sans"', "\n", "", "", 'normal 400 12px/1.2 "Noto Sans"' ]
```