### PR TITLE
Update package.json to point to src/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "12.4.1",
   "description": "Create OpenLayers maps from Mapbox Style objects",
   "type": "module",
-  "browser": "dist/index.js",
+  "browser": "src/index.js",
   "main": "dist/olms.js",
-  "module": "dist/index.js",
+  "module": "src/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Since dist/index.js no longer exists, values for browser and module needs to be updated accordingly. Without this we get errors when trying to import the package as a module.