### PR TITLE
Try to avoid layerName collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 13.0.0
+
+### Backwards incompatible changes
+
+* The MVT format parser now assigns the tile's `source-layer`s to the `mvt:layer` property of each feature. Previously the `layer` property was used, which was not ideal because it is frequently used in OpenStreetMap based tiles. This change may require application code changes where OpenLayers feature info (`Map.getFeaturesAtPixel()`, `Map.forEachFeatureAtPixel()`, `Layer.getFeatures()`) or style function customizations are used.
+
 ## 12.6.1
 
 * Make styles with `pitch` and `distance-from-center` expressions work again

--- a/src/MapboxVectorLayer.js
+++ b/src/MapboxVectorLayer.js
@@ -151,7 +151,7 @@ export default class MapboxVectorLayer extends VectorTileLayer {
     const declutter = 'declutter' in options ? options.declutter : true;
     const source = new VectorTileSource({
       state: 'loading',
-      format: new MVT(),
+      format: new MVT({layerName: 'mvt:layer'}),
     });
 
     super({

--- a/src/apply.js
+++ b/src/apply.js
@@ -661,7 +661,7 @@ export function setupVectorSource(glSource, styleUrl, options) {
           options,
         );
         sourceOptions.tileLoadFunction = tileLoadFunction;
-        sourceOptions.format = new MVT();
+        sourceOptions.format = new MVT({layerName: 'mvt:layer'});
         const source = new VectorTileSource(sourceOptions);
         source.set('mapbox-source', glSource);
         resolve(source);

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -533,7 +533,7 @@ export function stylefunction(
    */
   const styleFunction = function (feature, resolution, onlyLayer) {
     const properties = feature.getProperties();
-    const layers = layersBySourceLayer[properties.layer];
+    const layers = layersBySourceLayer[properties['mvt:layer']];
     if (!layers) {
       return undefined;
     }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -571,7 +571,7 @@ describe('util', function () {
                 [0, 0],
               ],
             ]),
-            layer: 'landuse',
+            'mvt:layer': 'landuse',
             class: 'park',
           });
           let styles = getStyle(feature, 1);
@@ -606,7 +606,7 @@ describe('util', function () {
                 [0, 0],
               ],
             ]),
-            layer: 'landuse',
+            'mvt:layer': 'landuse',
             class: 'park',
           });
           const styles = getStyle(feature, 1);


### PR DESCRIPTION
This pull request fixes a name collision with styles that have features with a property named `layer`, which is the internally used `layerName` property created by the `MVT` format.

This name collision was e.g. observed in the mapbox-streets-v12 map.