### PR TITLE
Clear text measure cache when loaded fonts have changed

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -1,4 +1,5 @@
 import mb2css from 'mapbox-to-css-font';
+import {checkedFonts} from 'ol/render/canvas.js';
 import {createCanvas} from './util.js';
 
 const hairSpacePool = Array(256).join('\u200A');
@@ -37,6 +38,12 @@ function measureText(text, letterSpacing) {
 }
 
 const measureCache = {};
+checkedFonts.on('propertychange', () => {
+  for (const key in measureCache) {
+    delete measureCache[key];
+  }
+});
+
 export function wrapText(text, font, em, letterSpacing) {
   if (text.indexOf('\n') !== -1) {
     const hardLines = text.split('\n');


### PR DESCRIPTION
This pull request fixes an issue where line breaks in texts may be inserted incorrectly or missing. That is when text width measurements were done before the correct font was loaded. The measure cache was never cleared.

This pull request ensures that the text measurements are cleared when new fonts are loaded, so text will be redrawn with the correct font *and* the correct line breaks when the correct font has finished loading.