### PR TITLE
Respect the 'layerName' property of the source format

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -369,6 +369,15 @@ export function applyStyle(
                 );
               }
             }
+            let layerProperty;
+            const source = layer.getSource();
+            if (source instanceof VectorTileSource) {
+              //@ts-ignore
+              if (source.format_ instanceof MVT) {
+                //@ts-ignore
+                layerProperty = source.format_.layerName_;
+              }
+            }
             style = applyStylefunction(
               layer,
               glStyle,
@@ -379,6 +388,7 @@ export function applyStyle(
               (fonts, templateUrl = options.webfonts) =>
                 getFonts(fonts, templateUrl),
               options.getImage,
+              layerProperty,
             );
             if (!layer.getStyle()) {
               reject(new Error(`Nothing to show for source [${sourceId}]`));

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -311,6 +311,13 @@ export function recordStyleLayer(record = false) {
 export const styleFunctionArgs = {};
 
 /**
+ * **Caution**: This is a low level API, which is only useful for advanced use cases.
+ * If you want to crete a map or layer group from an entire Mapbox/MapLibre style, use
+ * the `apply()` function. If you want to create a vector layer from a single
+ * source of a Mapbox/MapLibre style, use the `applyStyle()` function. If you want to
+ * create a vector tile layer from a single source of a Mapbox/MapLibre style, use either
+ * the `applyStyle()` function or the `MapboxVectorLayer` constructor.
+ *
  * Creates a style function from the `glStyle` object for all layers that use
  * the specified `source`, which needs to be a `"type": "vector"` or
  * `"type": "geojson"` source and applies it to the specified OpenLayers layer.
@@ -532,8 +539,11 @@ export function stylefunction(
    * @return {Array<import("ol/style/Style").default>} Style.
    */
   const styleFunction = function (feature, resolution, onlyLayer) {
+    const layerProperty =
+      //@ts-ignore
+      olLayer.getSource?.()?.format_?.layerName_ ?? 'mvt:layer';
     const properties = feature.getProperties();
-    const layers = layersBySourceLayer[properties['mvt:layer']];
+    const layers = layersBySourceLayer[properties[layerProperty]];
     if (!layers) {
       return undefined;
     }

--- a/test/applyStyle.test.js
+++ b/test/applyStyle.test.js
@@ -1,3 +1,6 @@
+import {Feature} from 'ol';
+import MVT from 'ol/format/MVT.js';
+import {Polygon} from 'ol/geom.js';
 import ImageLayer from 'ol/layer/Image.js';
 import VectorLayer from 'ol/layer/Vector.js';
 import VectorTileLayer from 'ol/layer/VectorTile.js';
@@ -307,6 +310,39 @@ describe('applyStyle without source creation', function () {
           should(layer.getSource().getAttributions()).be.null();
           should(layer.getSource().getTileLoadFunction()).equal(loader);
           should(layer.getStyle()).be.an.instanceOf(Function);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      })
+      .catch(function (e) {
+        done(e);
+      });
+  });
+  it('uses the layer property of the MVT format', function (done) {
+    const layer = new VectorTileLayer();
+    applyStyle(layer, '/fixtures/osm-liberty/style.json', 'openmaptiles')
+      .then(function () {
+        layer.setSource(
+          new VectorTileSource({
+            format: new MVT({layerName: 'my:layer'}),
+          }),
+        );
+        try {
+          const stylefunction = layer.getStyle();
+          const style = stylefunction(
+            new Feature({
+              'my:layer': 'park',
+              geometry: new Polygon([
+                [0, 0],
+                [1, 1],
+                [1, 0],
+                [0, 0],
+              ]),
+            }),
+            1,
+          );
+          should(style.length).be.greaterThan(0);
           done();
         } catch (e) {
           done(e);


### PR DESCRIPTION
By not assuming `mvt:layer`, we can avoid surprises when the source's format uses a different `layerName`.

See https://github.com/openlayers/openlayers/issues/17014