### PR TITLE
Make updateMapboxLayer work with raster layers

### DIFF
--- a/src/apply.js
+++ b/src/apply.js
@@ -1452,6 +1452,7 @@ export function addMapboxLayer(mapOrGroup, mapboxLayer, beforeLayerId) {
  * Update a Mapbox Layer object in the style. The map will be re-rendered with the new style.
  * @param {Map|LayerGroup} mapOrGroup The Map or LayerGroup `apply` was called on.
  * @param {Object} mapboxLayer Updated Mapbox Layer object.
+ * @return {Promise<void>} Resolves when the layer has been updated.
  */
 export function updateMapboxLayer(mapOrGroup, mapboxLayer) {
   const glStyle = mapOrGroup.get('mapbox-style');
@@ -1480,9 +1481,18 @@ export function updateMapboxLayer(mapOrGroup, mapboxLayer) {
     ];
   if (args) {
     applyStylefunction.apply(undefined, args);
-  } else {
-    getLayer(mapOrGroup, mapboxLayer.id).changed();
+    return Promise.resolve();
   }
+  const layer = getLayer(mapOrGroup, mapboxLayer.id);
+  const {options, styleUrl} = mapOrGroup.get('mapbox-metadata');
+  return finalizeLayer(
+    layer,
+    [mapboxLayer.id],
+    glStyle,
+    styleUrl,
+    mapOrGroup,
+    options,
+  );
 }
 
 /**

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,4 +1,5 @@
 import brightV9 from 'mapbox-gl-styles/styles/bright-v9.json';
+import satelliteV9 from 'mapbox-gl-styles/styles/satellite-v9.json';
 import {Feature} from 'ol';
 import Map from 'ol/Map.js';
 import {Polygon} from 'ol/geom.js';
@@ -569,7 +570,7 @@ describe('util', function () {
       target = document.createElement('div');
     });
 
-    it('updates a geojson source', function (done) {
+    it('updates a geojson source layer', function (done) {
       apply(target, JSON.parse(JSON.stringify(brightV9)))
         .then(function (map) {
           // add another layer that has no 'mapbox-layers' set
@@ -598,6 +599,27 @@ describe('util', function () {
           styles = getStyle(feature, 1);
           should(styles[0].getFill().getColor()).eql('rgba(0,0,255,1)');
           done();
+        })
+        .catch((err) => done(err));
+    });
+
+    it('updates a raster source layer', function (done) {
+      apply(target, JSON.parse(JSON.stringify(satelliteV9)))
+        .then((map) => {
+          const layer = getLayer(map, 'satellite');
+          const mapboxLayer = getMapboxLayer(map, 'satellite');
+          updateMapboxLayer(map, {
+            ...mapboxLayer,
+            minzoom: 16,
+          })
+            .then(() => {
+              should(layer.getMaxResolution()).approximately(
+                map.getView().getResolutionForZoom(16),
+                1e-9,
+              );
+              done();
+            })
+            .catch((err) => done(err));
         })
         .catch((err) => done(err));
     });


### PR DESCRIPTION
This pull request implements `updateMapboxStyle()` for raster layer, and changes the return type from `void` to `Promise<void>` so applications know when the style has changed.