### PR TITLE
Optimize style spec at pack time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 _site
 coverage
+src/stylespec.js.bak

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ webpack.*.cjs
 rollup.config.js
 tsconfig*.json
 typedoc.json
+src/stylespec.js.bak

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "13.4.2",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@maplibre/maplibre-gl-style-spec": "^26.4.0",
+        "@maplibre/maplibre-gl-style-spec": "^26.4.1",
         "mapbox-to-css-font": "^3.2.0"
       },
       "devDependencies": {
@@ -768,9 +768,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.0.tgz",
-      "integrity": "sha512-FHR/9P4g2MrO4+yAQvhIWJEQ34vEBwupoTyGXH4OUAPSeApoOq0Mqc53i4tU4UfTOWxr5KxGM74w9oxK+Snklw==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.1.tgz",
+      "integrity": "sha512-I/qcIKVFHFSg1Meu/eqHrkSTjIez0gCsSaK56TNPutM3TkE61aSq6F1cZ4Kg4KiNs3cpViLtubDjfyRcQCdEJQ==",
       "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -35,14 +35,20 @@
     "prepare": "npm run doc && npm run build",
     "build": "tsc --project tsconfig-build.json && rollup -c && webpack-cli --mode=production --config ./webpack.config.examples.cjs",
     "doc": "typedoc --plugin typedoc-plugin-missing-exports src/index.js --excludeExternals --tsconfig tsconfig-typecheck.json --out ./_site",
+    "style-spec:generate": "node tasks/style-spec.js generate",
+    "style-spec:restore": "node tasks/style-spec.js restore",
+    "prepack": "npm run style-spec:generate",
+    "postpack": "npm run style-spec:restore",
+    "style-spec:check": "node tasks/style-spec.js check",
     "karma": "karma start test/karma.conf.cjs",
-    "lint": "eslint test examples src",
+    "lint": "eslint test examples src tasks",
     "typecheck": "tsc --project tsconfig-typecheck.json",
-    "pretest": "npm run lint && npm run typecheck",
-    "test": "npm run karma -- --single-run --log-level error"
+    "pretest": "npm run style-spec:generate && npm run style-spec:check && npm run lint && npm run typecheck",
+    "test": "npm run karma -- --single-run --log-level error",
+    "posttest": "npm run style-spec:restore"
   },
   "dependencies": {
-    "@maplibre/maplibre-gl-style-spec": "^26.4.0",
+    "@maplibre/maplibre-gl-style-spec": "^26.4.1",
     "mapbox-to-css-font": "^3.2.0"
   },
   "peerDependencies": {

--- a/src/rasterfunction.js
+++ b/src/rasterfunction.js
@@ -189,6 +189,10 @@ export function configureHillshadeLayer(
     // colorArray values may be a single color string, a Color object,
     // or an array of color strings (for multidirectional).
     // Must distinguish ["#ff0000", "#00ff00"] from ["interpolate", ...].
+    /**
+     * @param {import('./stylefunction.js').PropertyOf<'paint'>} property Name.
+     * @return {Array<Color>|undefined} The colors.
+     */
     function getColorArray(property) {
       const raw = glLayer.paint?.[property];
       if (

--- a/src/stylefunction.js
+++ b/src/stylefunction.js
@@ -12,8 +12,9 @@ import {
   derefLayers,
   isExpression,
   isFunction,
-  v8 as spec,
 } from '@maplibre/maplibre-gl-style-spec';
+
+import spec from './stylespec.js';
 
 import mb2css from 'mapbox-to-css-font';
 import Map from 'ol/Map.js';
@@ -119,10 +120,28 @@ const expressionData = function (rawExpression, rootKey, propertySpec) {
 let renderFeatureCoordinates, renderFeature;
 
 /**
+ * The style reference, as a type: `Spec` has a key per `layout_*`/`paint_*`
+ * section, and each section a key per property it defines.
+ * @typedef {typeof import('./stylespec.js').default} Spec
+ */
+/**
+ * @template {string} S
+ * @typedef {S extends keyof Spec ? Extract<keyof Spec[S], string> : never} PropertiesIn
+ */
+/**
+ * Every property name the reference defines for `layout` or for `paint`. Asking
+ * `getValue()` for anything else is a type error, which is how a property that
+ * upstream has dropped gets caught.
+ * @template {'layout'|'paint'} K
+ * @typedef {PropertiesIn<Extract<keyof Spec, `${K}_${string}`>>} PropertyOf
+ */
+
+/**
  * @private
+ * @template {'layout'|'paint'} K
  * @param {Object} layer Gl object layer.
- * @param {string} layoutOrPaint 'layout' or 'paint'.
- * @param {string} property Feature property.
+ * @param {K} layoutOrPaint 'layout' or 'paint'.
+ * @param {PropertyOf<K>} property Feature property.
  * @param {Object} feature Gl feature.
  * @param {Object} [functionCache] Function cache.
  * @param {Object} [featureState] Feature state.
@@ -148,9 +167,11 @@ export function getValue(
   if (!functions[property]) {
     let value = (layer[layoutOrPaint] || emptyObj)[property];
     const rootKey = `layers[${layerId}].${layoutOrPaint}.${property}`;
+    // The section key is only known at runtime, so this one lookup is untyped.
+    const sections = /** @type {Object<string, any>} */ (spec);
     const propertySpec =
-      spec[`${layoutOrPaint}_${layer.type}`] &&
-      spec[`${layoutOrPaint}_${layer.type}`][property];
+      sections[`${layoutOrPaint}_${layer.type}`] &&
+      sections[`${layoutOrPaint}_${layer.type}`][property];
     if (value === undefined) {
       if (propertySpec) {
         value = propertySpec.default;
@@ -687,7 +708,7 @@ export function stylefunction(
           opacity = getValue(
             layer,
             'paint',
-            layer.type + '-opacity',
+            `${/** @type {'fill'|'fill-extrusion'} */ (layer.type)}-opacity`,
             f,
             functionCache,
             featureState,
@@ -696,7 +717,7 @@ export function stylefunction(
             const fillIcon = getValue(
               layer,
               'paint',
-              layer.type + '-pattern',
+              `${/** @type {'fill'|'fill-extrusion'} */ (layer.type)}-pattern`,
               f,
               functionCache,
               featureState,
@@ -757,7 +778,7 @@ export function stylefunction(
               getValue(
                 layer,
                 'paint',
-                layer.type + '-color',
+                `${/** @type {'fill'|'fill-extrusion'} */ (layer.type)}-color`,
                 f,
                 functionCache,
                 featureState,
@@ -769,7 +790,7 @@ export function stylefunction(
                 getValue(
                   layer,
                   'paint',
-                  layer.type + '-outline-color',
+                  `${/** @type {'fill'} */ (layer.type)}-outline-color`,
                   f,
                   functionCache,
                   featureState,

--- a/src/stylespec.js
+++ b/src/stylespec.js
@@ -1,0 +1,9 @@
+/*
+ol-mapbox-style - Use Mapbox/MapLibre Style objects with OpenLayers
+Copyright 2016-present ol-mapbox-style contributors
+License: https://raw.githubusercontent.com/openlayers/ol-mapbox-style/master/LICENSE
+*/
+
+import {v8} from '@maplibre/maplibre-gl-style-spec';
+
+export default v8;

--- a/tasks/style-spec.js
+++ b/tasks/style-spec.js
@@ -1,0 +1,267 @@
+/*
+ol-mapbox-style - Use Mapbox/MapLibre Style objects with OpenLayers
+Copyright 2016-present ol-mapbox-style contributors
+License: https://raw.githubusercontent.com/openlayers/ol-mapbox-style/master/LICENSE
+*/
+
+/**
+ * Writes the published form of `src/stylespec.js`: `layout_*`/`paint_*` only,
+ * reduced to the fields the expression engine reads, repeats spread from shared
+ * constants.
+ */
+
+import {expressions, v8} from '@maplibre/maplibre-gl-style-spec';
+import {execFileSync} from 'child_process';
+import {copyFileSync, existsSync, rmSync, writeFileSync} from 'fs';
+import {relative} from 'path';
+import {fileURLToPath} from 'url';
+
+const specFile = fileURLToPath(new URL('../src/stylespec.js', import.meta.url));
+const expressionsFile = fileURLToPath(
+  new URL('../src/expressions.js', import.meta.url),
+);
+const backupFile = `${specFile}.bak`;
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * Descriptor fields the expression engine reads.
+ * @type {Set<string>}
+ */
+const KEEP = new Set([
+  'default',
+  'expression',
+  'length',
+  'property-type',
+  'tokens',
+  'type',
+  'value',
+  'values',
+]);
+
+/**
+ * Descriptor fields nothing reads, listed so that a *new* upstream field is
+ * reported rather than dropped silently.
+ * @type {Set<string>}
+ */
+const DROP = new Set([
+  'maximum',
+  'minimum',
+  'overridable',
+  'period',
+  'requires',
+  'transition',
+  'units',
+]);
+
+/**
+ * @param {string} section Section name, e.g. `paint_line`.
+ * @param {string} property Property name, e.g. `line-width`.
+ * @return {Object} The descriptor, reduced to the fields the engine reads.
+ */
+function trimDescriptor(section, property) {
+  const descriptor = v8[section][property];
+  const trimmed = {};
+  const unknown = [];
+  for (const field of Object.keys(descriptor)) {
+    if (KEEP.has(field)) {
+      trimmed[field] = descriptor[field];
+    } else if (!DROP.has(field)) {
+      unknown.push(field);
+    }
+  }
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unrecognized field(s) on ${section}.${property}: ${unknown.sort().join(', ')}.\n` +
+        'Decide whether the expression engine reads them, then add each one to ' +
+        'KEEP or DROP in tasks/style-spec.js.',
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * @return {Object<string, Object<string, Object>>} Every `layout_*` and
+ *     `paint_*` descriptor in the stock reference, trimmed and sorted.
+ */
+function buildSpec() {
+  const spec = {};
+  const sections = Object.keys(v8)
+    .filter((section) => /^(layout|paint)_/.test(section))
+    .sort();
+  for (const section of sections) {
+    spec[section] = {};
+    for (const property of Object.keys(v8[section]).sort()) {
+      spec[section][property] = trimDescriptor(section, property);
+    }
+  }
+  return spec;
+}
+
+/**
+ * Half the descriptors repeat - `visibility` appears in every `layout_*`
+ * section - so each distinct body is emitted once and spread into the
+ * properties sharing it, which keeps every property its own object.
+ * @param {Object<string, Object<string, Object>>} spec The reference.
+ * @return {Map<string, string>} Constant name by descriptor JSON.
+ */
+function sharedDescriptors(spec) {
+  const uses = new Map();
+  for (const section of Object.keys(spec)) {
+    for (const property of Object.keys(spec[section])) {
+      const body = JSON.stringify(spec[section][property]);
+      uses.set(body, (uses.get(body) || 0) + 1);
+    }
+  }
+  const names = new Map();
+  const taken = new Set();
+  for (const section of Object.keys(spec)) {
+    for (const property of Object.keys(spec[section])) {
+      const descriptor = spec[section][property];
+      const body = JSON.stringify(descriptor);
+      if (uses.get(body) < 2 || names.has(body)) {
+        continue;
+      }
+      const base =
+        `${descriptor['property-type'] || 'any'}-${descriptor.type || 'any'}`
+          .toLowerCase()
+          .replace(/[^a-z0-9]+(.)/g, (match, character) =>
+            character.toUpperCase(),
+          );
+      let name = base;
+      for (let i = 2; taken.has(name); ++i) {
+        name = `${base}${i}`;
+      }
+      taken.add(name);
+      names.set(body, name);
+    }
+  }
+  return names;
+}
+
+/**
+ * @param {Object<string, Object<string, Object>>} spec The reference.
+ * @return {string} The contents of `src/stylespec.js`.
+ */
+function renderSpec(spec) {
+  const shared = sharedDescriptors(spec);
+  let constants = '';
+  for (const [body, name] of shared) {
+    constants += `const ${name} = ${JSON.stringify(JSON.parse(body), null, 2)};\n\n`;
+  }
+  let entries = '';
+  for (const section of Object.keys(spec)) {
+    entries += `  ${JSON.stringify(section)}: {\n`;
+    for (const property of Object.keys(spec[section])) {
+      const body = JSON.stringify(spec[section][property]);
+      const value = shared.has(body)
+        ? `{...${shared.get(body)}}`
+        : JSON.stringify(spec[section][property], null, 2);
+      entries += `    ${JSON.stringify(property)}: ${value},\n`;
+    }
+    entries += '  },\n';
+  }
+  return `/**
+ * GENERATED - run \`npm run style-spec:restore\` to restore the original.
+ */
+
+${constants}export default {
+${entries}};
+`;
+}
+
+/**
+ * Sets the current file aside, then writes the published form over it. An
+ * existing backup is left alone: it means a previous `generate` was never
+ * restored, and it, not the generated file, holds the original.
+ */
+function generate() {
+  if (!existsSync(backupFile)) {
+    copyFileSync(specFile, backupFile);
+  }
+  writeFileSync(specFile, renderSpec(buildSpec()));
+  execFileSync('npx', ['eslint', '--fix', specFile], {cwd: root});
+  // eslint-disable-next-line no-console
+  console.log(`Wrote ${relative(root, specFile)}.`);
+}
+
+/**
+ * Puts back whatever `generate` set aside. A no-op without a backup, so that a
+ * stray `postpack` cannot fail a publish.
+ */
+function restore() {
+  if (!existsSync(backupFile)) {
+    // eslint-disable-next-line no-console
+    console.log(`No ${relative(root, backupFile)} to restore.`);
+    return;
+  }
+  copyFileSync(backupFile, specFile);
+  rmSync(backupFile);
+  // eslint-disable-next-line no-console
+  console.log(`Restored ${relative(root, specFile)}.`);
+}
+
+/**
+ * `src/expressions.js` registers operators the stock engine lacks, so that
+ * Mapbox styles using them parse. If upstream adds one, the local definition
+ * silently wins.
+ * @return {Promise<Array<string>>} Problems found.
+ */
+async function checkExpressions() {
+  // The registry holds every expression; `definitions` only the compound ones.
+  const stock = new Map(Object.entries(expressions));
+  await import(expressionsFile);
+  const registered = Object.entries(expressions);
+  const problems = [];
+  const overridden = registered
+    .filter(
+      ([name, definition]) => stock.has(name) && stock.get(name) !== definition,
+    )
+    .map(([name]) => name);
+  if (overridden.length > 0) {
+    problems.push(
+      `src/expressions.js overrides ${overridden.sort().join(', ')}, which the ` +
+        'stock engine now defines itself. The local definition wins silently, ' +
+        'so drop it or record why it has to differ.',
+    );
+  }
+  return problems;
+}
+
+/**
+ * @return {Promise<Array<string>>} Problems found, empty if all is well.
+ */
+async function check() {
+  try {
+    // Throws on a descriptor field in neither KEEP nor DROP.
+    buildSpec();
+  } catch (error) {
+    return [error.message];
+  }
+  return checkExpressions();
+}
+
+const [command] = process.argv.slice(2);
+
+if (command === 'generate') {
+  generate();
+} else if (command === 'restore') {
+  restore();
+} else if (command === 'check') {
+  const problems = await check();
+  if (problems.length > 0) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `src/stylespec.js needs attention:\n\n${problems.map((p) => `  - ${p}`).join('\n')}\n`,
+    );
+    process.exit(1);
+  }
+} else {
+  // eslint-disable-next-line no-console
+  console.error(
+    'Usage:\n' +
+      '  node tasks/style-spec.js generate\n' +
+      '  node tasks/style-spec.js restore\n' +
+      '  node tasks/style-spec.js check',
+  );
+  process.exit(1);
+}

--- a/test/stylefunction-utils.test.js
+++ b/test/stylefunction-utils.test.js
@@ -111,7 +111,7 @@ describe('utility functions currently in stylefunction.js', function () {
       'id': 'park_outline',
       'paint': {
         'line-color': 'rgba(159, 183, 118, 0.69)',
-        'line-gap-width': {
+        'line-width': {
           'stops': [
             [12, 0],
             [20, 6],
@@ -154,7 +154,7 @@ describe('utility functions currently in stylefunction.js', function () {
 
     it('should get complex paint property', function () {
       cameraObj.zoom = 20;
-      const result = getValue(glLayer2, 'paint', 'line-gap-width', feature);
+      const result = getValue(glLayer2, 'paint', 'line-width', feature);
       should(result).equal(6);
     });
 


### PR DESCRIPTION
This pull request reduces the size of the library by shipping a much shorter style spec in the package — repeated properties added with spread operator, and unused properties removed. Currently removes 21 kB.