### PR TITLE
Create full build with optimized spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   "scripts": {
     "start": "webpack serve --config ./webpack.config.examples.cjs",
     "prepare": "npm run doc && npm run build",
+    "prebuild": "npm run style-spec:generate",
+    "postbuild": "npm run style-spec:restore",
     "build": "tsc --project tsconfig-build.json && rollup -c && webpack-cli --mode=production --config ./webpack.config.examples.cjs",
     "doc": "typedoc --plugin typedoc-plugin-missing-exports src/index.js --excludeExternals --tsconfig tsconfig-typecheck.json --out ./_site",
     "style-spec:generate": "node tasks/style-spec.js generate",


### PR DESCRIPTION
Follow-up on #1509, so the full build (olms.js) is created with the optimized spec instead of the full one.